### PR TITLE
Support Athena bigint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RAthena
 Type: Package
 Title: Connect to 'AWS Athena' using 'Boto3' ('DBI' Interface)
-Version: 1.2.0
+Version: 1.2.9000
 Authors@R: person("Dyfan", "Jones", email="dyfan.r.jones@gmail.com", 
                   role= c("aut", "cre"))
 Description: Designed to be compatible with the R package 'DBI' (Database Interface)
@@ -9,6 +9,7 @@ Description: Designed to be compatible with the R package 'DBI' (Database Interf
     To do this 'Python' 'Boto3' Software Development Kit ('SDK')
     <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html> is used as a driver.
 Imports: 
+    data.table,
     DBI (>= 0.7),
     methods,
     reticulate (>= 1.13),
@@ -16,7 +17,7 @@ Imports:
     utils
 Suggests: 
     arrow,
-    data.table,
+    bit64,
     dplyr,
     dbplyr,
     testthat

--- a/R/DataTypes.R
+++ b/R/DataTypes.R
@@ -27,7 +27,7 @@ AthenaToRDataType <- function(data_type){
          integer = "integer",
          tinyint = "integer",
          smallint = "integer",
-         bigint = "integer",
+         bigint = "integer64",
          float = "double",
          decimal = "double",
          string = "character",

--- a/R/RAthena.R
+++ b/R/RAthena.R
@@ -18,7 +18,8 @@
 #' without needing hard code any credentials.
 #' 
 #' @import reticulate
-#' @importFrom utils packageVersion read.csv write.table
+#' @importFrom utils packageVersion
 #' @importFrom stats runif
 #' @import DBI
+#' @import data.table
 "_PACKAGE"

--- a/R/Result.R
+++ b/R/Result.R
@@ -176,17 +176,15 @@ setMethod(
     Type <- AthenaToRDataType(result_class$ResultSet$ResultSetMetadata$ColumnInfo)
     
     if(grepl("\\.csv$",result_info$key)){
-      if (requireNamespace("data.table", quietly=TRUE)){output <- data.table::fread(File, col.names = names(Type), colClasses = unname(Type))}
-      else {output <- read_athena(File, Type)}
+      output <- data.table::fread(File, col.names = names(Type), colClasses = unname(Type))
     } else{
       file_con <- file(File)
       output <- suppressWarnings(readLines(file_con))
       close(file_con)
       if(any(grepl("create|table", output, ignore.case = T))){
-        output <-data.frame("TABLE_DDL" = paste0(output, collapse = "\n"), stringsAsFactors = FALSE)
+        output <- data.frame("TABLE_DDL" = paste0(output, collapse = "\n"), stringsAsFactors = FALSE)
       } else (output <- data.frame(var1 = trimws(output), stringsAsFactors = FALSE))
     }
-    
     return(output)
   })
 

--- a/R/table.R
+++ b/R/table.R
@@ -99,14 +99,9 @@ Athena_write_table <-
     }
 
     # writes out csv/tsv, uses data.table for extra speed
-    if (requireNamespace("data.table", quietly=TRUE)){
-      switch(file.type,
-             "csv" = data.table::fwrite(value, t),
-             "tsv" = data.table::fwrite(value, t, sep = "\t"))
-    } else {
-      switch(file.type,
-             "csv" = write.table(value, t, sep = ",", row.names = FALSE, quote=FALSE),
-             "tsv" = write.table(value, t, sep = "\t", row.names = FALSE, quote=FALSE))}
+    switch(file.type,
+           "csv" = data.table::fwrite(value, t),
+           "tsv" = data.table::fwrite(value, t, sep = "\t"))
 
     found <- dbExistsTable(conn, Name)
     if (found && !overwrite && !append) {

--- a/R/util.R
+++ b/R/util.R
@@ -183,21 +183,3 @@ pkg_method <- function(fun, pkg) {
   fun_name <- utils::getFromNamespace(fun, pkg)
   return(fun_name)
 }
-
-# convert character to logical
-char_log <- function(value, athena_class){
-  col_want <- sapply(athena_class, function(x) x == "logical")
-  for (i in seq_along(which(col_want))) {
-    want = which(value[[which(col_want)[i]]] == "true")
-    output = rep(FALSE, times = nrow(value))
-    output[want] = TRUE
-    value[[which(col_want)[i]]] <- output
-  }
-  value
-}
-
-# simple wrapper to correct miss classification
-read_athena <- function(file, athena_class){
-  output <- read.csv(file, col.names = names(athena_class), stringsAsFactors = F) 
-  char_log(output, athena_class)
-}

--- a/tests/testthat/test-datatransfer.R
+++ b/tests/testthat/test-datatransfer.R
@@ -21,6 +21,11 @@ test_that("Testing data transfer between R and athena", {
                    z = sample(c(TRUE, FALSE), 10, replace = T),
                    stringsAsFactors = F)
   
+  # testing if bigint is transferred correctly
+  df2 <- data.frame(var1 = sample(letters, 10, replace = T),
+                   var2 = bit64::as.integer64(1:10),
+                   stringsAsFactors = F)
+  
   DATE <- Sys.Date()
   dbWriteTable(con, "test_df", df, overwrite = T, partition = c("timesTamp" = format(DATE, "%Y%m%d")), s3.location = s3.location1)
   dbWriteTable(con, "test_df2", df, 
@@ -29,10 +34,13 @@ test_that("Testing data transfer between R and athena", {
                              "month" = format(DATE, "%m"),
                              "DAY" = format(DATE, "%d")),
                s3.location = s3.location2)
+  dbWriteTable(con, "df_bigint", df2, overwrite = T, s3.location = s3.location2)
   
   # if data.table is available in namespace result returned as data.table
-  test_df <- as.data.frame(dbGetQuery(con, paste0("select x, y, z from test_df where timestamp ='",format(Sys.Date(), "%Y%m%d"),"'")))
-  test_df2 <- as.data.frame(dbGetQuery(con, paste0("select x, y, z from test_df2 where year = '",format(DATE, "%Y"), "' and month = '",format(DATE, "%m"), "' and day = '", format(DATE, "%d"),"'")))
+  test_df <- as.data.frame(dbGetQuery(con, paste0("select x, y, z from test_df where timestamp ='", format(Sys.Date(), "%Y%m%d"),"'")))
+  test_df2 <- as.data.frame(dbGetQuery(con, paste0("select x, y, z from test_df2 where year = '", format(DATE, "%Y"), "' and month = '",format(DATE, "%m"), "' and day = '", format(DATE, "%d"),"'")))
+  test_df3 <- as.data.frame(dbGetQuery(con, "select * from df_bigint"))
   expect_equal(test_df,df)
   expect_equal(test_df2,df)
+  expect_equal(test_df3,df2)
 })


### PR DESCRIPTION
Previous version of RAthena didn't fully support Athena big. To fix this data.table is going to be ued as the default file parser. This gives two big advantages: 

- `colClass` can be passed to it in vector format (unable to find similar solution for `readr`, `readr` opts for `col_type` to passed in `cols` format https://readr.tidyverse.org/reference/cols.html)
- The raw read and write speed of data.table will increase the transfer of data between R and Athena