### PR TITLE
S3 uri

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RAthena
 Type: Package
 Title: Connect to 'AWS Athena' using 'Boto3' ('DBI' Interface)
-Version: 1.3.0.9000
+Version: 1.3.0.9001
 Authors@R: person("Dyfan", "Jones", email="dyfan.r.jones@gmail.com", 
                   role= c("aut", "cre"))
 Description: Designed to be compatible with the R package 'DBI' (Database Interface)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,22 @@
+# RAthena 1.3.0.9001
+### Minor Change
+* `s3.location` parameter is `dbWriteTable` can now be made nullable
+
+### Backend Change
+* helper function `upload_data` has been rebuilt and removed the old "horrible" if statement with `paste` now the function relies on `sprintf` to construct the s3 location path. This method now is alot clearer in how the s3 location is created plus it enables a `dbWriteTable` to be simplified. `dbWriteTable` can now upload data to the default s3_staging directory created in `dbConnect` this simplifies `dbWriteTable` to :
+```
+library(DBI)
+
+con <- dbConnect(RAthena::athena())
+
+dbWrite(con, "iris", iris)
+```
+### Bug Fix
+* Info message wasn't being return when colnames needed changing for Athena DDL
+
+### Unit Tests
+* `data transfer` test now tests compress, and default s3.location when transfering data
+
 # RAthena 1.3.0.9000
 ### New Feature
 * GZIP compression is now supported for "csv" and "tsv" file format in `dbWriteTable`

--- a/R/table.R
+++ b/R/table.R
@@ -13,6 +13,7 @@
 #' @param field.types Additional field types used to override derived types.
 #' @param partition Partition Athena table (needs to be a named list or vector) for example: \code{c(var1 = "2019-20-13")}
 #' @param s3.location s3 bucket to store Athena table, must be set as a s3 uri for example ("s3://mybucket/data/"). 
+#'        By default s3.location is set s3 staging directory from \code{\linkS4class{AthenaConnection}} object.
 #' @param file.type What file type to store data.frame on s3, RAthena currently supports ["csv", "tsv", "parquet"].
 #'                  \strong{Note:} "parquet" format is supported by the \code{arrow} package and it will need to be installed to utilise the "parquet" format.
 #' @param compress \code{FALSE | TRUE} To determine if to compress file.type. If file type is ["csv", "tsv"] then "gzip" compression is used.
@@ -49,6 +50,18 @@
 #' 
 #' # Checking if uploaded table exists in Athena
 #' dbExistsTable(con, "mtcars")
+#' 
+#' # using default s3.location
+#' dbWriteTable(con, "iris", iris)
+#' 
+#' # Read entire table from Athena
+#' dbReadTable(con, "iris")
+#'
+#' # List all tables in Athena after uploading new table to Athena
+#' dbListTables(con)
+#' 
+#' # Checking if uploaded table exists in Athena
+#' dbExistsTable(con, "iris")
 #'
 #' # Disconnect from Athena
 #' dbDisconnect(con)
@@ -66,7 +79,7 @@ Athena_write_table <-
               is.data.frame(value),
               is.logical(overwrite),
               is.logical(append),
-              is.s3_uri(s3.location),
+              is.null(s3.location) || is.s3_uri(s3.location),
               is.null(partition) || is.character(partition) || is.list(partition),
               is.logical(compress))
 
@@ -74,6 +87,9 @@ Athena_write_table <-
       stop("partition ", x, " is a variable in data.frame ", deparse(substitute(value)), call. = FALSE)}})
     
     file.type = match.arg(file.type)
+    
+    # use default s3_staging directory is s3.location isn't provided
+    if (is.null(s3.location)) s3.location <- conn@info$s3_staging
     
     # made everything lower case due to aws Athena issue: https://aws.amazon.com/premiumsupport/knowledge-center/athena-aws-glue-msck-repair-table/
     name <- tolower(name)
@@ -146,24 +162,28 @@ Athena_write_table <-
 
 # send data to s3 is Athena registered location
 upload_data <- function(con, x, name, partition = NULL, s3.location= NULL,  file.type = NULL, compress = NULL) {
+  # formatting s3 partitions
   partition <- unlist(partition)
   partition <- paste(names(partition), unname(partition), sep = "=", collapse = "/")
+  if (partition != "") partition <- paste0(partition, "/")
   
+  # s3_file name
   FileType <- if(compress) Compress(file.type, compress) else file.type
-  Name <- paste(name, FileType, sep = ".")
+  FileName <- paste(name, FileType, sep = ".")
+  
+  # s3 bucket and key split
   s3_info <- split_s3_uri(s3.location)
   s3_info$key <- gsub("/$", "", s3_info$key)
   split_key <- unlist(strsplit(s3_info$key,"/"))
   
   if(split_key[length(split_key)] == name || length(split_key) == 0) split_key[length(split_key)] <- ""
   s3_info$key <- paste(split_key, collapse = "/")
+  if (s3_info$key != "") s3_info$key <- paste0(s3_info$key, "/")
   
-  if(s3_info$key != "" && partition == ""){s3_key <- paste(s3_info$key,name, Name, sep = "/")}
-  else if (s3_info$key == "" && partition != "") {s3_key <- paste(name, partition, Name, sep = "/")}
-  else if (s3_info$key == "" && partition == "") {s3_key <- paste(name, Name, sep = "/")}
-  else if (split_key[length(split_key)] != name || length(split_key) != 0) {
-    s3_key <- paste(s3_info$key, partition, Name, sep = "/")}
-  else {s3_key <- paste(s3_info$key, name, partition, Name, sep = "/")}
+  # s3 folder
+  name <- paste0(name, "/")
+  
+  s3_key <- sprintf("%s%s%s%s", s3_info$key, name, partition, FileName)
   
   tryCatch(s3 <- con@ptr$resource("s3"),
            error = function(e) py_error(e))
@@ -216,7 +236,6 @@ setMethod(
                       partition, s3.location, file.type, compress)
   })
 
-
 #' Converts data frame into suitable format to be uploaded to Athena
 #'
 #' This method converts data.frame columns into the correct format so that it can be uploaded Athena.
@@ -232,7 +251,10 @@ NULL
 setMethod("sqlData", "AthenaConnection", function(con, value, row.names = NA, ...) {
   stopifnot(is.data.frame(value))
   value <- sqlRownamesToColumn(value, row.names)
-  names(value) <- tolower(gsub("\\.", "_", make.names(names(value), unique = TRUE)))
+  field_names <- tolower(gsub("\\.", "_", make.names(names(value), unique = TRUE)))
+  DIFF <- setdiff(field_names, names(value))
+  names(value) <- field_names
+  if (length(DIFF) > 0) message("Info: data.frame colnames have been converted to align with Athena DDL naming convertions: \n",paste0(DIFF, collapse= ",\n"))
   for(i in seq_along(value)){
     if(is.list(value[[i]])){
       value[[i]] <- sapply(value[[i]], paste, collapse = "|")
@@ -249,6 +271,7 @@ setMethod("sqlData", "AthenaConnection", function(con, value, row.names = NA, ..
 #' @param field.types Additional field types used to override derived types.
 #' @param partition Partition Athena table (needs to be a named list or vector) for example: \code{c(var1 = "2019-20-13")}
 #' @param s3.location s3 bucket to store Athena table, must be set as a s3 uri for example ("s3://mybucket/data/"). 
+#'        By default s3.location is set s3 staging directory from \code{\linkS4class{AthenaConnection}} object.
 #' @param file.type What file type to store data.frame on s3, RAthena currently supports ["csv", "tsv", "parquet"]
 #' @param compress \code{FALSE | TRUE} To determine if to compress file.type. If file type is ["csv", "tsv"] then "gzip" compression is used.
 #'        Currently parquet compression isn't supported.
@@ -294,11 +317,14 @@ setMethod("sqlCreateTable", "AthenaConnection",
               is.data.frame(fields),
               is.null(field.types) || is.character(field.types),
               is.null(partition) || is.character(partition) || is.list(partition),
-              is.s3_uri(s3.location),
+              is.null(s3.location) || is.s3_uri(s3.location),
               is.logical(compress))
     
     field <- createFields(con, fields, field.types = field.types)
     file.type <- match.arg(file.type)
+    
+    # use default s3_staging directory is s3.location isn't provided
+    if (is.null(s3.location)) s3.location <- con@info$s3_staging
 
     table1 <- gsub(".*\\.", "", table)
     
@@ -357,7 +383,6 @@ header <- function(obj, compress){
          tsv = paste0('TBLPROPERTIES ("skip.header.line.count"="1"',compress,');'),
          parquet = paste0(compress,";"))
 }
-
 
 Compress <- function(file.type, compress){
   if(compress){

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,9 +1,11 @@
 ## Release Summary
-This is a feature updated, focusing on the setting `data.table` as the default file parser and handling of 'AWS Athena' `bigint` classes
+This is a feature updated, focusing on methods to compress flat files before submitting them to `Amazon Web Service S3`. 
 
 In this version I have:
-* Correctly pass Amazon Web Service ('AWS') Athena `bigint` to R `integer64` class.
-* data.table has been made a dependency as `fread` and `fwrite` have been made the default file parsers to transfer data to and from 'AWS Athena'
+* created a new parameter in `dbWriteTable` called `compress` that enables compression method `gzip` to be utilised when sending data to AWS S3.
+
+**Bug Fix**
+* Fixed minor bug of s3_uri being incorrectly built
 
 ## Examples Note:
 * All R examples with `\dontrun` & `\donttest` have been given a note warning users that `AWS credentials` are required to run
@@ -20,7 +22,7 @@ In this version I have:
 0 errors ✔ | 0 warnings ✔ | 0 notes ✔
 
 ## unit tests (using testthat) results
-* OK:       37
+* OK:       38
 * Failed:   0
 * Warnings: 0
 * Skipped:  0

--- a/man/AthenaWriteTables.Rd
+++ b/man/AthenaWriteTables.Rd
@@ -54,7 +54,8 @@ For backward compatibility, \code{NULL} is equivalent to \code{FALSE}.}
 
 \item{partition}{Partition Athena table (needs to be a named list or vector) for example: \code{c(var1 = "2019-20-13")}}
 
-\item{s3.location}{s3 bucket to store Athena table, must be set as a s3 uri for example ("s3://mybucket/data/").}
+\item{s3.location}{s3 bucket to store Athena table, must be set as a s3 uri for example ("s3://mybucket/data/"). 
+By default s3.location is set s3 staging directory from \code{\linkS4class{AthenaConnection}} object.}
 
 \item{file.type}{What file type to store data.frame on s3, RAthena currently supports ["csv", "tsv", "parquet"].
 \strong{Note:} "parquet" format is supported by the \code{arrow} package and it will need to be installed to utilise the "parquet" format.}
@@ -99,6 +100,18 @@ dbListTables(con)
 
 # Checking if uploaded table exists in Athena
 dbExistsTable(con, "mtcars")
+
+# using default s3.location
+dbWriteTable(con, "iris", iris)
+
+# Read entire table from Athena
+dbReadTable(con, "iris")
+
+# List all tables in Athena after uploading new table to Athena
+dbListTables(con)
+
+# Checking if uploaded table exists in Athena
+dbExistsTable(con, "iris")
 
 # Disconnect from Athena
 dbDisconnect(con)

--- a/man/sqlCreateTable.Rd
+++ b/man/sqlCreateTable.Rd
@@ -30,7 +30,8 @@ A data frame: field types are generated using
 
 \item{partition}{Partition Athena table (needs to be a named list or vector) for example: \code{c(var1 = "2019-20-13")}}
 
-\item{s3.location}{s3 bucket to store Athena table, must be set as a s3 uri for example ("s3://mybucket/data/").}
+\item{s3.location}{s3 bucket to store Athena table, must be set as a s3 uri for example ("s3://mybucket/data/"). 
+By default s3.location is set s3 staging directory from \code{\linkS4class{AthenaConnection}} object.}
 
 \item{file.type}{What file type to store data.frame on s3, RAthena currently supports ["csv", "tsv", "parquet"]}
 

--- a/tests/testthat/test-datatransfer.R
+++ b/tests/testthat/test-datatransfer.R
@@ -26,6 +26,9 @@ test_that("Testing data transfer between R and athena", {
                    var2 = bit64::as.integer64(1:10),
                    stringsAsFactors = F)
   
+  mtcars2 <- mtcars
+  row.names(mtcars2) <- NULL
+  
   DATE <- Sys.Date()
   dbWriteTable(con, "test_df", df, overwrite = T, partition = c("timesTamp" = format(DATE, "%Y%m%d")), s3.location = s3.location1)
   dbWriteTable(con, "test_df2", df, 
@@ -35,12 +38,17 @@ test_that("Testing data transfer between R and athena", {
                              "DAY" = format(DATE, "%d")),
                s3.location = s3.location2)
   dbWriteTable(con, "df_bigint", df2, overwrite = T, s3.location = s3.location2)
+  dbWriteTable(con, "mtcars2", mtcars2, overwrite = T, compress = T)
   
   # if data.table is available in namespace result returned as data.table
   test_df <- as.data.frame(dbGetQuery(con, paste0("select x, y, z from test_df where timestamp ='", format(DATE, "%Y%m%d"),"'")))
   test_df2 <- as.data.frame(dbGetQuery(con, paste0("select x, y, z from test_df2 where year = '", format(DATE, "%Y"), "' and month = '",format(DATE, "%m"), "' and day = '", format(DATE, "%d"),"'")))
   test_df3 <- as.data.frame(dbGetQuery(con, "select * from df_bigint"))
+  test_df4 <- as.data.frame(dbGetQuery(con, "select * from mtcars2"))
   expect_equal(test_df,df)
   expect_equal(test_df2,df)
   expect_equal(test_df3,df2)
+  expect_equal(test_df4, mtcars2)
 })
+
+


### PR DESCRIPTION
enabled default method for `s3.location` in `dbWriteTable`. Now data can be sent to Athena with the follow command:

```
library(DBI)

con <- dbConnect(RAthena::athena())

dbWriteTable(con, "iris", iris)
```

This should make it easier for users and look more familiar to other databases when using `DBI` 