### PR TITLE
fixed bug for older versions of R

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -312,7 +312,7 @@ NULL
 #' @rdname sqlCreateTable
 #' @export
 setMethod("sqlCreateTable", "AthenaConnection",
-  function(con, table = NULL, fields = NULL, field.types = NULL, partition = NULL, s3.location= NULL, file.type = c("csv", "tsv", "parquet"), 
+  function(con, table, fields, field.types = NULL, partition = NULL, s3.location= NULL, file.type = c("csv", "tsv", "parquet"), 
            compress = FALSE, ...){
     if (!dbIsValid(con)) {stop("Connection already closed.", call. = FALSE)}
     stopifnot(is.character(table),

--- a/R/table.R
+++ b/R/table.R
@@ -322,7 +322,7 @@ setMethod("sqlCreateTable", "AthenaConnection",
               is.null(s3.location) || is.s3_uri(s3.location),
               is.logical(compress))
     
-    field <- createFields(con, fields, field.types = field.types)
+    field <- createFields(con, fields = fields, field.types = field.types)
     file.type <- match.arg(file.type)
     
     # use default s3_staging directory is s3.location isn't provided

--- a/R/table.R
+++ b/R/table.R
@@ -146,7 +146,7 @@ Athena_write_table <-
     upload_data(conn, FileLocation, name, partition, s3.location, file.type, compress)
     
     if (!append) {
-      sql <- sqlCreateTable(conn, Name, value, field.types = field.types, 
+      sql <- sqlCreateTable(conn, table = Name, fields = value, field.types = field.types, 
                             partition = names(partition),
                             s3.location = s3.location, file.type = file.type,
                             compress = compress)

--- a/man/AthenaWriteTables.Rd
+++ b/man/AthenaWriteTables.Rd
@@ -60,8 +60,8 @@ By default s3.location is set s3 staging directory from \code{\linkS4class{Athen
 \item{file.type}{What file type to store data.frame on s3, RAthena currently supports ["csv", "tsv", "parquet"].
 \strong{Note:} "parquet" format is supported by the \code{arrow} package and it will need to be installed to utilise the "parquet" format.}
 
-\item{compress}{\code{FALSE | TRUE} To determine if to compress file.type. If file type is ["csv", "tsv"] then "gzip" compression is used.
-Currently parquet compression isn't supported.}
+\item{compress}{\code{FALSE | TRUE} To determine if to compress file.type. If file type is ["csv", "tsv"] then "gzip" compression is used, for file type "parquet" 
+"snappy" compression is used.}
 
 \item{...}{Other arguments used by individual methods.}
 }

--- a/man/sqlCreateTable.Rd
+++ b/man/sqlCreateTable.Rd
@@ -6,10 +6,9 @@
 \alias{sqlCreateTable,AthenaConnection-method}
 \title{Creates query to create a simple Athena table}
 \usage{
-\S4method{sqlCreateTable}{AthenaConnection}(con, table = NULL,
-  fields = NULL, field.types = NULL, partition = NULL,
-  s3.location = NULL, file.type = c("csv", "tsv", "parquet"),
-  compress = FALSE, ...)
+\S4method{sqlCreateTable}{AthenaConnection}(con, table, fields,
+  field.types = NULL, partition = NULL, s3.location = NULL,
+  file.type = c("csv", "tsv", "parquet"), compress = FALSE, ...)
 }
 \arguments{
 \item{con}{A database connection.}


### PR DESCRIPTION
Older versions of R are getting confused with the method `sqlCreateTable`. This is due to the method setting parameters `table` and `fields` to NULL