### PR TITLE
Fix formatting errors with timestamp on write and read

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RAthena
 Type: Package
 Title: Connect to 'AWS Athena' using 'Boto3' ('DBI' Interface)
-Version: 1.4.1.9000
+Version: 1.4.1.9002
 Authors@R: person("Dyfan", "Jones", email="dyfan.r.jones@gmail.com", 
                   role= c("aut", "cre"))
 Description: Designed to be compatible with the R package 'DBI' (Database Interface)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 ### Bug Fixed
 Thanks to @OssiLehtinen for identifying issue around `sql_translate_env`. Previously `RAthena` would take the default `dplyr::sql_translate_env`, now `RAthena` has a custom method that uses Data types from: https://docs.aws.amazon.com/athena/latest/ug/data-types.html and window functions from: https://docs.aws.amazon.com/athena/latest/ug/functions-operators-reference-section.html
 
+### Unit tests
+* `dplyr sql_translate_env` tests if R functions are correct translated in to Athena sql syntax.
+
 # RAthena 1.4.1
 ### New Features:
 * Parquet file type can now be compress using snappy compression when writting data to S3.

--- a/R/Connection.R
+++ b/R/Connection.R
@@ -306,20 +306,8 @@ setMethod(
 #' @rdname dbQuote
 #' @export
 setMethod(
-  "dbQuoteIdentifier", c("AthenaConnection", "character"),
-  function(conn, x, ...) {
-    if (length(x) == 0L) {
-      return(DBI::SQL(character()))
-    }
-    if (any(is.na(x))) {
-      stop("Cannot pass NA to dbQuoteIdentifier()", call. = FALSE)
-    }
-    if (nzchar(conn@quote)) {
-      x <- gsub(conn@quote, paste0(conn@quote, conn@quote), x, fixed = TRUE)
-    }
-    DBI::SQL(paste(conn@quote, encodeString(x), conn@quote, sep = ""))
-  })
-
+  "dbQuoteIdentifier", c("AthenaConnection", "SQL"),
+  getMethod("dbQuoteIdentifier", c("DBIConnection", "SQL"), asNamespace("DBI")))
 
 #' List Athena Tables
 #'

--- a/R/Result.R
+++ b/R/Result.R
@@ -181,7 +181,7 @@ setMethod(
       # currently parameter data.table is left as default. If users require data.frame to be returned then parameter will be updated
       output <- data.table::fread(File, col.names = names(Type2), colClasses = unname(Type2), showProgress = F, na.strings="")
       # formatting POSIXct: from string to POSIXct
-      for (col in names(Type[Type %in% "POSIXct"])) set(output, j=col, value=as.POSIXct(output[[col]], format="%Y-%m-%d %H:%M:%S"))
+      for (col in names(Type[Type %in% "POSIXct"])) set(output, j=col, value=as.POSIXct(output[[col]]))
     } else{
       file_con <- file(File)
       output <- suppressWarnings(readLines(file_con))

--- a/R/Result.R
+++ b/R/Result.R
@@ -177,7 +177,7 @@ setMethod(
     
     if(grepl("\\.csv$",result_info$key)){
       # currently parameter data.table is left as default. If users require data.frame to be returned then parameter will be updated
-      output <- data.table::fread(File, col.names = names(Type), colClasses = unname(Type), showProgress = F)
+      output <- data.table::fread(File, col.names = names(Type), colClasses = unname(Type), showProgress = F, na.strings="")
     } else{
       file_con <- file(File)
       output <- suppressWarnings(readLines(file_con))

--- a/R/Result.R
+++ b/R/Result.R
@@ -173,11 +173,15 @@ setMethod(
     tryCatch(result_class <- res@athena$get_query_results(QueryExecutionId = res@info$QueryExecutionId, MaxResults = as.integer(1)),
              error = function(e) py_error(e))
     
-    Type <- AthenaToRDataType(result_class$ResultSet$ResultSetMetadata$ColumnInfo)
+    Type2 <- Type <- AthenaToRDataType(result_class$ResultSet$ResultSetMetadata$ColumnInfo)
+    # Type2 is to handle issue with data.table fread 
+    Type2[Type2 %in% "POSIXct"] <- "character"
     
     if(grepl("\\.csv$",result_info$key)){
       # currently parameter data.table is left as default. If users require data.frame to be returned then parameter will be updated
-      output <- data.table::fread(File, col.names = names(Type), colClasses = unname(Type), showProgress = F, na.strings="")
+      output <- data.table::fread(File, col.names = names(Type2), colClasses = unname(Type2), showProgress = F, na.strings="")
+      # formatting POSIXct: from string to POSIXct
+      for (col in names(Type[Type %in% "POSIXct"])) set(output, j=col, value=as.POSIXct(output[[col]]))
     } else{
       file_con <- file(File)
       output <- suppressWarnings(readLines(file_con))

--- a/R/Result.R
+++ b/R/Result.R
@@ -181,7 +181,7 @@ setMethod(
       # currently parameter data.table is left as default. If users require data.frame to be returned then parameter will be updated
       output <- data.table::fread(File, col.names = names(Type2), colClasses = unname(Type2), showProgress = F, na.strings="")
       # formatting POSIXct: from string to POSIXct
-      for (col in names(Type[Type %in% "POSIXct"])) set(output, j=col, value=as.POSIXct(output[[col]]))
+      for (col in names(Type[Type %in% "POSIXct"])) set(output, j=col, value=as.POSIXct(output[[col]], format="%Y-%m-%d %H:%M:%S"))
     } else{
       file_con <- file(File)
       output <- suppressWarnings(readLines(file_con))

--- a/R/table.R
+++ b/R/table.R
@@ -340,6 +340,7 @@ setMethod("sqlCreateTable", "AthenaConnection",
     if (is.null(s3.location)) s3.location <- con@info$s3_staging
 
     table1 <- gsub(".*\\.", "", table)
+    table <- dbQuoteIdentifier(con, table)
     
     s3.location <- gsub("/$", "", s3.location)
     if(grepl(table1, s3.location)){s3.location <- gsub(paste0("/", table1,"$"), "", s3.location)}
@@ -367,6 +368,8 @@ createFields <- function(con, fields, field.types) {
   field_names <- tolower(gsub("\\.", "_", make.names(names(fields), unique = TRUE)))
   DIFF <- setdiff(field_names, names(fields))
   if (length(DIFF) > 0) message("Info: data.frame colnames have been converted to align with Athena DDL naming convertions: \n",paste0(DIFF, collapse= ",\n"))
+  
+  field_names <- dbQuoteIdentifier(con, field_names)
   field.types <- unname(fields)
   paste0(field_names, " ", field.types)
 }

--- a/R/table.R
+++ b/R/table.R
@@ -109,6 +109,11 @@ Athena_write_table <-
     on.exit({unlink(t)
              if(!is.null(conn@info$expiration)) time_check(conn@info$expiration)})
 
+    # Force formatting of timestamps
+    timestampcols <- sapply(sapply(value, class), FUN = function(x) "POSIXct" %in% x)
+    if(sum(timestampcols) == 1) value[, timestampcols] <- strftime(value[,timestampcols], format="%Y-%m-%d %H:%M:%S.000000")
+    if(sum(timestampcols) > 1) value[, timestampcols] <- apply(value[,timestampcols], 2, function(x) strftime(x, format="%Y-%m-%d %H:%M:%S.000000"))
+    
     value <- sqlData(conn, value, row.names = row.names)
     
     # compress file

--- a/R/table.R
+++ b/R/table.R
@@ -110,7 +110,7 @@ Athena_write_table <-
              if(!is.null(conn@info$expiration)) time_check(conn@info$expiration)})
 
     # return original Athena Types
-    if(is.null(field.types)) field.types <- dbDataType(con, value)
+    if(is.null(field.types)) field.types <- dbDataType(conn, value)
     value <- sqlData(conn, value, row.names = row.names)
     
     # compress file

--- a/R/table.R
+++ b/R/table.R
@@ -267,6 +267,7 @@ setMethod("sqlData", "AthenaConnection", function(con, value, row.names = NA, ..
   
   # preprosing proxict format
   posixct_cols<- names(Value)[sapply(col_types, function(x) "POSIXct" %in% x)]
+  # create timestamp in athena format: https://docs.aws.amazon.com/athena/latest/ug/data-types.html
   for (col in posixct_cols) set(Value, j=col, value=strftime(Value[[col]], format="%Y-%m-%d %H:%M:%OS3"))
   
   # preprosing list format

--- a/R/table.R
+++ b/R/table.R
@@ -267,7 +267,7 @@ setMethod("sqlData", "AthenaConnection", function(con, value, row.names = NA, ..
   
   # preprosing proxict format
   posixct_cols<- names(Value)[sapply(col_types, function(x) "POSIXct" %in% x)]
-  for (col in posixct_cols) set(Value, j=col, value=strftime(Value[[col]], format="%Y-%m-%d %H:%M:%S.000000"))
+  for (col in posixct_cols) set(Value, j=col, value=strftime(Value[[col]], format="%Y-%m-%d %H:%M:%OS3"))
   
   # preprosing list format
   list_cols <- names(Value)[sapply(col_types, function(x) "list" %in% x)]

--- a/man/dbQuote.Rd
+++ b/man/dbQuote.Rd
@@ -4,12 +4,12 @@
 \name{dbQuote}
 \alias{dbQuote}
 \alias{dbQuoteString,AthenaConnection,character-method}
-\alias{dbQuoteIdentifier,AthenaConnection,SQL-method}
+\alias{dbQuoteIdentifier,AthenaConnection,character-method}
 \title{Quote Identifiers}
 \usage{
 \S4method{dbQuoteString}{AthenaConnection,character}(conn, x, ...)
 
-\S4method{dbQuoteIdentifier}{AthenaConnection,SQL}(conn, x, ...)
+\S4method{dbQuoteIdentifier}{AthenaConnection,character}(conn, x, ...)
 }
 \arguments{
 \item{conn}{A subclass of \linkS4class{DBIConnection}, representing

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -15,9 +15,9 @@ skip_if_no_env <- function(){
 # expected athena ddl's
 tbl_ddl <- 
   list(tbl1 = 
-DBI::SQL(paste0("CREATE EXTERNAL TABLE test_df (
-  x INT,
-  y STRING
+DBI::SQL(paste0("CREATE EXTERNAL TABLE `test_df` (
+  `x` INT,
+  `y` STRING
 )
 ROW FORMAT DELIMITED
 	FIELDS TERMINATED BY ','
@@ -26,9 +26,9 @@ ROW FORMAT DELIMITED
 "\nLOCATION '",Sys.getenv("rathena_s3_tbl"),"test_df/'
 TBLPROPERTIES (\"skip.header.line.count\"=\"1\");")),
 tbl2 = 
-DBI::SQL(paste0("CREATE EXTERNAL TABLE test_df (
-  x INT,
-  y STRING
+DBI::SQL(paste0("CREATE EXTERNAL TABLE `test_df` (
+  `x` INT,
+  `y` STRING
 )
 ROW FORMAT DELIMITED
 	FIELDS TERMINATED BY '\t'
@@ -37,14 +37,14 @@ ROW FORMAT DELIMITED
            "\nLOCATION '",Sys.getenv("rathena_s3_tbl"),"test_df/'
 TBLPROPERTIES (\"skip.header.line.count\"=\"1\");")), 
 tbl3 = 
-  DBI::SQL(paste0("CREATE EXTERNAL TABLE test_df (
-  x INT,
-  y STRING
+  DBI::SQL(paste0("CREATE EXTERNAL TABLE `test_df` (
+  `x` INT,
+  `y` STRING
 )
 STORED AS PARQUET
 LOCATION '",Sys.getenv("rathena_s3_tbl"),"test_df/'\n;")),
 tbl4 = 
-  DBI::SQL(paste0("CREATE EXTERNAL TABLE test_df (\n  x INT,\n  y STRING\n)
+  DBI::SQL(paste0("CREATE EXTERNAL TABLE `test_df` (\n  `x` INT,\n  `y` STRING\n)
 PARTITIONED BY (timestamp STRING)
 STORED AS PARQUET
 LOCATION '",Sys.getenv("rathena_s3_tbl"),"test_df/'\n;")))

--- a/tests/testthat/test-datatransfer.R
+++ b/tests/testthat/test-datatransfer.R
@@ -16,7 +16,8 @@ test_that("Testing data transfer between R and athena", {
                    profile_name = "rathena",
                    s3_staging_dir = Sys.getenv("rathena_s3_query"))
   
-  df <- data.frame(x = 1:10,
+  df <- data.frame(w = as.POSIXct((Sys.time() -9):Sys.time(), origin = "1970-01-01"),
+                   x = 1:10,
                    y = letters[1:10], 
                    z = sample(c(TRUE, FALSE), 10, replace = T),
                    stringsAsFactors = F)
@@ -41,10 +42,15 @@ test_that("Testing data transfer between R and athena", {
   dbWriteTable(con, "mtcars2", mtcars2, overwrite = T, compress = T)
   
   # if data.table is available in namespace result returned as data.table
-  test_df <- as.data.frame(dbGetQuery(con, paste0("select x, y, z from test_df where timestamp ='", format(DATE, "%Y%m%d"),"'")))
-  test_df2 <- as.data.frame(dbGetQuery(con, paste0("select x, y, z from test_df2 where year = '", format(DATE, "%Y"), "' and month = '",format(DATE, "%m"), "' and day = '", format(DATE, "%d"),"'")))
+  test_df <- as.data.frame(dbGetQuery(con, paste0("select w, x, y, z from test_df where timestamp ='", format(DATE, "%Y%m%d"),"'")))
+  test_df2 <- as.data.frame(dbGetQuery(con, paste0("select w, x, y, z from test_df2 where year = '", format(DATE, "%Y"), "' and month = '",format(DATE, "%m"), "' and day = '", format(DATE, "%d"),"'")))
   test_df3 <- as.data.frame(dbGetQuery(con, "select * from df_bigint"))
   test_df4 <- as.data.frame(dbGetQuery(con, "select * from mtcars2"))
+  
+  # due the nature of POSIXct have to cast POSIXct to string to compare
+  # test_df$w <- strftime(test_df$w, format="%Y-%m-%d %H:%M:%S")
+  # df$w <- strftime(df$w, format="%Y-%m-%d %H:%M:%S")
+  
   expect_equal(test_df,df)
   expect_equal(test_df2,df)
   expect_equal(test_df3,df2)

--- a/tests/testthat/test-datatransfer.R
+++ b/tests/testthat/test-datatransfer.R
@@ -47,10 +47,6 @@ test_that("Testing data transfer between R and athena", {
   test_df3 <- as.data.frame(dbGetQuery(con, "select * from df_bigint"))
   test_df4 <- as.data.frame(dbGetQuery(con, "select * from mtcars2"))
   
-  # due the nature of POSIXct have to cast POSIXct to string to compare
-  # test_df$w <- strftime(test_df$w, format="%Y-%m-%d %H:%M:%S")
-  # df$w <- strftime(df$w, format="%Y-%m-%d %H:%M:%S")
-  
   expect_equal(test_df,df)
   expect_equal(test_df2,df)
   expect_equal(test_df3,df2)

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -5,8 +5,8 @@ context("Athena Metadata")
 # Sys.getenv("rathena_s3_query"): "s3://path/to/query/bucket/"
 # Sys.getenv("rathena_s3_tbl"): "s3://path/to/bucket/"
 
-df_col_info <- data.frame(field_name = c("x","y", "z", "timestamp"),
-                          type = c("integer", "varchar", "boolean", "varchar"), stringsAsFactors = F)
+df_col_info <- data.frame(field_name = c("w","x","y", "z", "timestamp"),
+                          type = c("timestamp", "integer", "varchar", "boolean", "varchar"), stringsAsFactors = F)
 
 test_that("Returning meta data from query",{
   skip_if_no_boto()


### PR DESCRIPTION
The following data.table causes two fold problems when written into and read from athena:
```r
natable <- data.frame(
    a = c(Sys.time(), as.POSIXct("2019-12-31 00:00:00"), NA, as.POSIXct("2019-12-31 23:59:59.999999")), 
    b = c(1, 2, 3, NaN),
    c = c("g", NA, "h", "i")
  )

a_t <- copy_to(con, natable, "test")
a_t
```
First, data.table::fwrite formats the timestamps as iso8601, which does not work with Athena's/Presto's timestamp column type, and empty rows are returned.

The commit to table.R addresses this in a 'hacky' way, by forcing the formatting of the timstamp-columns to something Athena understands and writing them as character-fields. Since this is done after the column definitions are generated, the columns appear as timestamps in Athena.
NB! I do not have Arrow running, so I have no idea what happens when writing as parquet.


Second, empty entries are returned as "" from Athena when reading, and parsing as POSIXct fails with these. Consequently timestamp cols are reverted to strings. 

The commit to result.R addresses this issue, but telling data.table::fread to treat "" as NA.


