### PR TITLE
added numpy into install_boto to help reticulate bind with RAthena environment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,7 @@ dbGetQuery(con, "select * from iris2")
 
 ## Bug Fix
 * `dbWriteTable` appending to existing table compress file type was incorrectly return.
+* `install_boto` added `numpy` to `RAthena` environment install as `reticulate` appears to favour environments with `numpy` (https://github.com/rstudio/reticulate/issues/216)
 
 ## Documentation
 * Added supported environmental variable `AWS_REGION` into `dbConnect`

--- a/R/install.R
+++ b/R/install.R
@@ -11,7 +11,7 @@
 #' @param envname Name of Python environment to install within, by default environment name RAthena.
 #'
 #' @param conda_python_version the python version installed in the created conda
-#'   environment. Python 3.6 is installed by default.
+#'   environment. Python 3.7 is installed by default.
 #'
 #' @param ... other arguments passed to [reticulate::conda_install()] or
 #'   [reticulate::virtualenv_install()].
@@ -23,7 +23,7 @@
 install_boto <- function(method = c("auto", "virtualenv", "conda"),
                          conda = "auto",
                          envname = "RAthena",
-                         conda_python_version = "3.6",
+                         conda_python_version = "3.7",
                          ...) {
   method <- match.arg(method)
   stopifnot(is.character(envname))

--- a/R/install.R
+++ b/R/install.R
@@ -28,8 +28,9 @@ install_boto <- function(method = c("auto", "virtualenv", "conda"),
   method <- match.arg(method)
   stopifnot(is.character(envname))
   
+  # added numpy to help reticulate bind to environment: https://github.com/rstudio/reticulate/issues/216
   reticulate::py_install(
-    packages       = c("cython","boto3"),
+    packages       = c("cython","boto3","numpy"),
     envname        = envname,
     method         = method,
     conda          = conda,

--- a/docs/articles/getting_started.html
+++ b/docs/articles/getting_started.html
@@ -126,17 +126,17 @@
 <div id="python-environments" class="section level2">
 <h2 class="hasAnchor">
 <a href="#python-environments" class="anchor"></a>Python Environments:</h2>
-<p>As <code>RAthena</code> utilises Python for the connection, please make sure that the correct Python environment is enabled before you make a connection to <code>AWS Athena</code>:</p>
+<p>If <code>RAthena</code> doesn’t pick up <code>boto3</code> after using <code><a href="../reference/install_boto.html">install_boto()</a></code>, please consider specifying the python environment.<code><a href="../reference/install_boto.html">install_boto()</a></code> creates <code>RAthena</code> environment. This is either a Python virtual environment or a conda environment depending on your system.</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" title="1"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(DBI)</a>
 <a class="sourceLine" id="cb4-2" title="2"></a>
-<a class="sourceLine" id="cb4-3" title="3"><span class="co"># specifying python conda environment</span></a>
-<a class="sourceLine" id="cb4-4" title="4">reticulate<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/reticulate/man/use_python.html">use_condaenv</a></span>(<span class="st">"RAthena"</span>)</a>
+<a class="sourceLine" id="cb4-3" title="3"><span class="co"># Specify python conda environment and force reticulate to use it</span></a>
+<a class="sourceLine" id="cb4-4" title="4">reticulate<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/reticulate/man/use_python.html">use_condaenv</a></span>(<span class="st">"RAthena"</span>, <span class="dt">required =</span> <span class="ot">TRUE</span>)</a>
 <a class="sourceLine" id="cb4-5" title="5"></a>
-<a class="sourceLine" id="cb4-6" title="6"><span class="co"># Or specifying python virtual enviroment</span></a>
-<a class="sourceLine" id="cb4-7" title="7">reticulate<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/reticulate/man/use_python.html">use_virtualenv</a></span>(<span class="st">"RAthena"</span>)</a>
+<a class="sourceLine" id="cb4-6" title="6"><span class="co"># Or specify python virtual environment and force reticulate to use it</span></a>
+<a class="sourceLine" id="cb4-7" title="7">reticulate<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/reticulate/man/use_python.html">use_virtualenv</a></span>(<span class="st">"RAthena"</span>, <span class="dt">required =</span> <span class="ot">TRUE</span>)</a>
 <a class="sourceLine" id="cb4-8" title="8"></a>
 <a class="sourceLine" id="cb4-9" title="9">con &lt;-<span class="st"> </span><span class="kw"><a href="../reference/dbConnect-AthenaDriver-method.html">dbConnect</a></span>(RAthena<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/RAthena/man/athena.html">athena</a></span>())</a></code></pre></div>
-<p><strong>Note:</strong> Python enviroments are not required if <code>boto3</code> is either in the root Python or if R and Python are in their own enviroment (for example conda enviroment).</p>
+<p><strong>Note:</strong> Python environments are not required if <code>boto3</code> is either in the root Python or if R and Python are in their own enviroment (for example conda environment).</p>
 </div>
 </div>
 <div id="usage" class="section level1">
@@ -222,12 +222,12 @@
 <a href="#dplyr" class="anchor"></a>dplyr:</h2>
 <div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" title="1"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(dplyr)</a>
 <a class="sourceLine" id="cb7-2" title="2"></a>
-<a class="sourceLine" id="cb7-3" title="3">athena_iris &lt;-<span class="st"> </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/tbl.html">tbl</a></span>(con, <span class="st">"iris"</span>)</a>
+<a class="sourceLine" id="cb7-3" title="3">athena_iris &lt;-<span class="st"> </span><span class="kw"><a href="https://rdrr.io/pkg/dplyr/man/tbl.html">tbl</a></span>(con, <span class="st">"iris"</span>)</a>
 <a class="sourceLine" id="cb7-4" title="4"></a>
 <a class="sourceLine" id="cb7-5" title="5">athena_iris <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb7-6" title="6"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(species, sepal_length, sepal_width) <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb7-6" title="6"><span class="st">  </span><span class="kw"><a href="https://rdrr.io/pkg/dplyr/man/select.html">select</a></span>(species, sepal_length, sepal_width) <span class="op">%&gt;%</span><span class="st"> </span></a>
 <a class="sourceLine" id="cb7-7" title="7"><span class="st">  </span><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(<span class="dv">10</span>) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb7-8" title="8"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/compute.html">collect</a></span>()</a>
+<a class="sourceLine" id="cb7-8" title="8"><span class="st">  </span><span class="kw"><a href="https://rdrr.io/pkg/dplyr/man/compute.html">collect</a></span>()</a>
 <a class="sourceLine" id="cb7-9" title="9"><span class="co"># Info: (Data scanned: 860 Bytes)</span></a>
 <a class="sourceLine" id="cb7-10" title="10"><span class="co"># # A tibble: 10 x 3</span></a>
 <a class="sourceLine" id="cb7-11" title="11"><span class="co"># species  sepal_length sepal_width</span></a>

--- a/docs/reference/install_boto.html
+++ b/docs/reference/install_boto.html
@@ -142,7 +142,7 @@
   <span class='kw'>method</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"auto"</span>, <span class='st'>"virtualenv"</span>, <span class='st'>"conda"</span>),
   <span class='kw'>conda</span> <span class='kw'>=</span> <span class='st'>"auto"</span>,
   <span class='kw'>envname</span> <span class='kw'>=</span> <span class='st'>"RAthena"</span>,
-  <span class='kw'>conda_python_version</span> <span class='kw'>=</span> <span class='st'>"3.6"</span>,
+  <span class='kw'>conda_python_version</span> <span class='kw'>=</span> <span class='st'>"3.7"</span>,
   <span class='no'>...</span>
 )</pre>
 
@@ -169,7 +169,7 @@ PATH and other conventional install locations).</p></td>
     <tr>
       <th>conda_python_version</th>
       <td><p>the python version installed in the created conda
-environment. Python 3.6 is installed by default.</p></td>
+environment. Python 3.7 is installed by default.</p></td>
     </tr>
     <tr>
       <th>...</th>

--- a/docs/reference/sqlCreateTable.html
+++ b/docs/reference/sqlCreateTable.html
@@ -253,7 +253,7 @@ Athena due to the separating value ",". This would cause issues with AWS Athena.
 #&gt;   `Petal_Width` DOUBLE,
 #&gt;   `Species` STRING
 #&gt; )
-#&gt; PARTITIONED BY (20200309 STRING)
+#&gt; PARTITIONED BY (20200310 STRING)
 #&gt; ROW FORMAT DELIMITED
 #&gt; 	FIELDS TERMINATED BY '	'
 #&gt; 	LINES TERMINATED BY '\n'
@@ -274,7 +274,7 @@ Athena due to the separating value ",". This would cause issues with AWS Athena.
 #&gt;   `Petal_Width` DOUBLE,
 #&gt;   `Species` STRING
 #&gt; )
-#&gt; PARTITIONED BY (20200309 STRING)
+#&gt; PARTITIONED BY (20200310 STRING)
 #&gt; STORED AS PARQUET
 #&gt; LOCATION 's3://path/to/athena/table/default/iris/'
 #&gt; ;</div><div class='input'>

--- a/man/install_boto.Rd
+++ b/man/install_boto.Rd
@@ -8,7 +8,7 @@ install_boto(
   method = c("auto", "virtualenv", "conda"),
   conda = "auto",
   envname = "RAthena",
-  conda_python_version = "3.6",
+  conda_python_version = "3.7",
   ...
 )
 }
@@ -25,7 +25,7 @@ PATH and other conventional install locations).}
 \item{envname}{Name of Python environment to install within, by default environment name RAthena.}
 
 \item{conda_python_version}{the python version installed in the created conda
-environment. Python 3.6 is installed by default.}
+environment. Python 3.7 is installed by default.}
 
 \item{...}{other arguments passed to [reticulate::conda_install()] or
 [reticulate::virtualenv_install()].}

--- a/vignettes/getting_started.Rmd
+++ b/vignettes/getting_started.Rmd
@@ -39,21 +39,21 @@ pip install boto3
 
 ## Python Environments:
 
-As `RAthena` utilises Python for the connection, please make sure that the correct Python environment is enabled before you make a connection to `AWS Athena`:
+If `RAthena` doesn't pick up `boto3` after using `install_boto()`, please consider specifying the python environment.`install_boto()` creates `RAthena` environment. This is either a Python virtual environment or a conda environment depending on your system. 
 
 ```r
 library(DBI)
 
-# specifying python conda environment
-reticulate::use_condaenv("RAthena")
+# Specify python conda environment and force reticulate to use it
+reticulate::use_condaenv("RAthena", required = TRUE)
 
-# Or specifying python virtual enviroment
-reticulate::use_virtualenv("RAthena")
+# Or specify python virtual environment and force reticulate to use it
+reticulate::use_virtualenv("RAthena", required = TRUE)
 
 con <- dbConnect(RAthena::athena())
 ```
 
-**Note:** Python enviroments are not required if `boto3` is either in the root Python or if R and Python are in their own enviroment (for example conda enviroment).
+**Note:** Python environments are not required if `boto3` is either in the root Python or if R and Python are in their own enviroment (for example conda environment).
 
 # Usage:
 


### PR DESCRIPTION
It appears that `reticulate` struggles to bind to python environments without numpy: https://github.com/rstudio/reticulate/issues/216