### PR TITLE
bug fix: glue call aborting list table when user doesn't have s3 permissons.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RAthena
 Type: Package
 Title: Connect to 'AWS Athena' using 'Boto3' ('DBI' Interface)
-Version: 1.10.0
+Version: 1.10.1
 Authors@R: person("Dyfan", "Jones", email="dyfan.r.jones@gmail.com", 
                   role= c("aut", "cre"))
 Description: Designed to be compatible with the R package 'DBI' (Database Interface)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# RAthena 1.10.1
+## Bug Fix
+* Do not abort if a glue::get_tables api call fails (e.g., due to missing permissions to a specific database or an orphaned Lake Formation resource link) when retrieving a list of database tables with dbListTables, dbGetTables or in Rstudio's Connections pane. Thanks to @OssiLehtinen creating solution ([noctua: # 106](https://github.com/DyfanJones/noctua/pull/106))
+* Allowed cache_size to equal 100
+
 # RAthena 1.10.0
 ## New Feature
 * RAthena now supports Keyboard Interrupt and will stop AWS Athena running the query when the query has been interrupted. To keep the functionality of AWS Athena running when `R` has been interrupt a new parameter has been added to `dbConnect`, `keyboard_interrupt`. Example:

--- a/R/Connection.R
+++ b/R/Connection.R
@@ -366,7 +366,7 @@ setMethod(
     
     if(is.null(schema)){
       retry_api_call(schema <- sapply(glue$get_databases()$DatabaseList,function(x) x$Name))}
-    tryCatch(output <- lapply(schema, function (x) glue$get_tables(DatabaseName = x)$TableList),
+    tryCatch(output <- lapply(schema, function (x) tryCatch(glue$get_tables(DatabaseName = x)$TableList, error = function(cond) NULL)),
              error = function(e) py_error(e))
     unlist(lapply(output, function(x) sapply(x, function(y) y$Name)))
   }
@@ -413,7 +413,7 @@ setMethod("dbGetTables", "AthenaConnection",
     glue <- conn@ptr$client("glue")
   if(is.null(schema)){
     retry_api_call(schema <- sapply(glue$get_databases()$DatabaseList,function(x) x$Name))}
-  tryCatch(output <- lapply(schema, function (x) glue$get_tables(DatabaseName = x)$TableList),
+  tryCatch(output <- lapply(schema, function (x) tryCatch(glue$get_tables(DatabaseName = x)$TableList, error = function(cond) NULL)),
            error = function(e) py_error(e))
   rbindlist(lapply(output, function(x) rbindlist(lapply(x, function(y) data.frame(Schema = y$DatabaseName,
                                                                                   TableName=y$Name,

--- a/R/Options.R
+++ b/R/Options.R
@@ -40,7 +40,7 @@ RAthena_options <- function(file_parser = c("data.table", "vroom"), cache_size =
             is.numeric(cache_size),
             is.logical(retry_quiet))
   
-  if(cache_size < 0 | cache_size >= 100) stop("RAthena currently only supports up to 100 queries being cached", call. = F)
+  if(cache_size < 0 | cache_size > 100) stop("RAthena currently only supports up to 100 queries being cached", call. = F)
   if(retry < 0) stop("Number of retries is required to be greater than 0.")
   
   if (!requireNamespace(file_parser, quietly = TRUE)) 

--- a/R/View.R
+++ b/R/View.R
@@ -169,7 +169,7 @@ AthenaTableTypes <- function(connection, database = NULL, name = NULL, ...) {
     tryCatch(database <- sapply(glue$get_databases()$DatabaseList,function(x) x$Name),
              error = function(e) py_error(e))}
   if(is.null(name)){
-    tryCatch(output <- lapply(database, function (x) glue$get_tables(DatabaseName = x)$TableList),
+    tryCatch(output <- lapply(database, function (x) tryCatch(glue$get_tables(DatabaseName = x)$TableList, error = function(cond) NULL)),
              error = function(e) py_error(e))
     tbl_meta <- unlist(lapply(output, function(x) sapply(x, TblMeta)))}
   else{

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,8 +1,9 @@
 ## Release Summary
-This release brings new a feature to the package.
+This release brings in bug fixes.
 
-**New Features**
-* RAthena now supports keyboard interrupt. `AWS Athena` queries will now be stop when a keyboard interrupt happens within R.
+**Bug Fix**
+* `RAthena_options` parameter `cache_size` now correctly uses the range [0,100]
+*  Do not abort if a `AWS Glue` `get_tables` api call fails
 
 ## Examples Note:
 * All R examples with `\dontrun` have been given a note warning users that `AWS credentials` are required to run

--- a/docs/404.html
+++ b/docs/404.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/articles/aws_athena_query_caching.html
+++ b/docs/articles/aws_athena_query_caching.html
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/articles/aws_s3_backend.html
+++ b/docs/articles/aws_s3_backend.html
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/articles/changing_backend_file_parser.html
+++ b/docs/articles/changing_backend_file_parser.html
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/articles/convert_and_save_cost.html
+++ b/docs/articles/convert_and_save_cost.html
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/articles/getting_started.html
+++ b/docs/articles/getting_started.html
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/articles/how_to_retry.html
+++ b/docs/articles/how_to_retry.html
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/issue_template.html
+++ b/docs/issue_template.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 
@@ -141,6 +141,19 @@
       <small>Source: <a href='https://github.com/DyfanJones/RAthena/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
+    <div id="rathena-1101" class="section level1">
+<h1 class="page-header" data-toc-text="1.10.1">
+<a href="#rathena-1101" class="anchor"></a>RAthena 1.10.1<small> Unreleased </small>
+</h1>
+<div id="bug-fix" class="section level2">
+<h2 class="hasAnchor">
+<a href="#bug-fix" class="anchor"></a>Bug Fix</h2>
+<ul>
+<li>Do not abort if a glue::get_tables api call fails (e.g., due to missing permissions to a specific database or an orphaned Lake Formation resource link) when retrieving a list of database tables with dbListTables, dbGetTables or in Rstudio’s Connections pane. Thanks to <a href='https://github.com/OssiLehtinen'>@OssiLehtinen</a> creating solution (<a href="https://github.com/DyfanJones/noctua/pull/106">noctua: # 106</a>)</li>
+<li>Allowed cache_size to equal 100</li>
+</ul>
+</div>
+</div>
     <div id="rathena-1100" class="section level1">
 <h1 class="page-header" data-toc-text="1.10.0">
 <a href="#rathena-1100" class="anchor"></a>RAthena 1.10.0<small> 2020-08-06 </small>
@@ -215,9 +228,9 @@
 <li>Added <code>region_name</code> check before making a connection to AWS Athena (<a href='https://github.com/DyfanJones/RAthena/issues/110'>#110</a>)</li>
 </ul>
 </div>
-<div id="bug-fix" class="section level2">
+<div id="bug-fix-1" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fix" class="anchor"></a>Bug Fix</h2>
+<a href="#bug-fix-1" class="anchor"></a>Bug Fix</h2>
 <ul>
 <li>
 <code>dbWriteTable</code> would throw <code>throttling error</code> every now and again, <code>retry_api_call</code> as been built to handle the parsing of data between R and AWS S3.</li>
@@ -283,9 +296,9 @@
 
 <span class="fu"><a href="../reference/dbGetQuery.html">dbGetQuery</a></span>(<span class="no">con</span>, <span class="st">"select * from iris2"</span>)</pre></div>
 </div>
-<div id="bug-fix-1" class="section level2">
+<div id="bug-fix-2" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fix-1" class="anchor"></a>Bug Fix</h2>
+<a href="#bug-fix-2" class="anchor"></a>Bug Fix</h2>
 <ul>
 <li>
 <code>dbWriteTable</code> appending to existing table compress file type was incorrectly return.</li>
@@ -323,9 +336,9 @@
 <h1 class="page-header" data-toc-text="1.7.1">
 <a href="#rathena-171" class="anchor"></a>RAthena 1.7.1<small> 2020-02-16 </small>
 </h1>
-<div id="bug-fix-2" class="section level2">
+<div id="bug-fix-3" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fix-2" class="anchor"></a>Bug Fix</h2>
+<a href="#bug-fix-3" class="anchor"></a>Bug Fix</h2>
 <ul>
 <li>Dependency data.table now restricted to (&gt;=1.12.4) due to file compression being added to <code>fwrite</code> (&gt;=1.12.4) <a href="https://github.com/Rdatatable/data.table/blob/master/NEWS.md" class="uri">https://github.com/Rdatatable/data.table/blob/master/NEWS.md</a>
 </li>
@@ -473,9 +486,9 @@
 <li>Due to help from <a href='https://github.com/OssiLehtinen'>@OssiLehtinen</a>, <code>dbRemoveTable</code> can now remove S3 files for AWS Athena table being removed.</li>
 </ul>
 </div>
-<div id="bug-fix-3" class="section level2">
+<div id="bug-fix-4" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fix-3" class="anchor"></a>Bug fix</h2>
+<a href="#bug-fix-4" class="anchor"></a>Bug fix</h2>
 <ul>
 <li>Due to issue highlighted by <a href='https://github.com/OssiLehtinen'>@OssiLehtinen</a> in <a href='https://github.com/DyfanJones/RAthena/issues/50'>#50</a>, special characters have issue being processed when using flat file in the backend.</li>
 <li>Fixed issue where <code>as.character</code> was getting wrongly translated <a href='https://github.com/DyfanJones/RAthena/issues/45'>#45</a></li>
@@ -553,9 +566,9 @@
 </li>
 </ul>
 </div>
-<div id="bug-fix-4" class="section level2">
+<div id="bug-fix-5" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fix-4" class="anchor"></a>Bug Fix</h2>
+<a href="#bug-fix-5" class="anchor"></a>Bug Fix</h2>
 <ul>
 <li>Fixed bug in regards to Athena DDL being created incorrectly when passed from <code>dbWriteTable</code>
 </li>
@@ -589,9 +602,9 @@
 <li>Parquet file type can now be compress using snappy compression when writing data to S3.</li>
 </ul>
 </div>
-<div id="bug-fix-5" class="section level2">
+<div id="bug-fix-6" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fix-5" class="anchor"></a>Bug Fix</h2>
+<a href="#bug-fix-6" class="anchor"></a>Bug Fix</h2>
 <ul>
 <li>Older versions of R are returning errors when function <code>dbWriteTable</code> is called. The bug is due to function <code>sqlCreateTable</code> which <code>dbWriteTable</code> calls. Parameters <code>table</code> and <code>fields</code> were set to <code>NULL</code>. This has now been fixed.</li>
 </ul>
@@ -631,9 +644,9 @@
 </li>
 </ul>
 </div>
-<div id="bug-fix-6" class="section level2">
+<div id="bug-fix-7" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fix-6" class="anchor"></a>Bug Fix</h2>
+<a href="#bug-fix-7" class="anchor"></a>Bug Fix</h2>
 <ul>
 <li>Info message wasn’t being return when colnames needed changing for Athena DDL</li>
 </ul>
@@ -756,9 +769,9 @@
 <li>Created s3 method for function <code>db_copy_to</code> for better integration with dplyr</li>
 </ul>
 </div>
-<div id="bug-fix-7" class="section level2">
+<div id="bug-fix-8" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fix-7" class="anchor"></a>Bug Fix</h2>
+<a href="#bug-fix-8" class="anchor"></a>Bug Fix</h2>
 <ul>
 <li>
 <code>dbFetch</code> Athena data type miss alignment</li>
@@ -821,9 +834,9 @@
 <li>Added <code>stop_query_execution</code> to <code>dbClearResult</code> if the query is still running</li>
 </ul>
 </div>
-<div id="bug-fix-8" class="section level2">
+<div id="bug-fix-9" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fix-8" class="anchor"></a>Bug Fix</h2>
+<a href="#bug-fix-9" class="anchor"></a>Bug Fix</h2>
 <ul>
 <li>Fixed bug of miss-alignment of s3 location and Athena table on lower level folder structures, when writing data.frame to Athena (using <code>dbWriteTable</code>)</li>
 </ul>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -8,5 +8,5 @@ articles:
   convert_and_save_cost: convert_and_save_cost.html
   getting_started: getting_started.html
   how_to_retry: how_to_retry.html
-last_built: 2020-08-06T10:15Z
+last_built: 2020-09-25T13:59Z
 

--- a/docs/reference/AthenaConnection.html
+++ b/docs/reference/AthenaConnection.html
@@ -73,7 +73,7 @@ for AthenaConnection objects." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/AthenaDriver.html
+++ b/docs/reference/AthenaDriver.html
@@ -73,7 +73,7 @@ for AthenaDriver objects." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/AthenaWriteTables.html
+++ b/docs/reference/AthenaWriteTables.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/Query.html
+++ b/docs/reference/Query.html
@@ -74,7 +74,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/RAthena-package.html
+++ b/docs/reference/RAthena-package.html
@@ -73,7 +73,7 @@ Boto3." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/RAthena_options.html
+++ b/docs/reference/RAthena_options.html
@@ -73,7 +73,7 @@ whether RAthena should cache query ids locally and number of retries on a failed
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/assume_role.html
+++ b/docs/reference/assume_role.html
@@ -74,7 +74,7 @@ your account or for cross-account access." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/athena.html
+++ b/docs/reference/athena.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/backend_dbplyr.html
+++ b/docs/reference/backend_dbplyr.html
@@ -74,7 +74,7 @@ utilise AWS Glue to speed up sql query execution." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbClearResult.html
+++ b/docs/reference/dbClearResult.html
@@ -73,7 +73,7 @@ stopping query execution if still running and removed the connection resource lo
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbColumnInfo.html
+++ b/docs/reference/dbColumnInfo.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbConnect-AthenaDriver-method.html
+++ b/docs/reference/dbConnect-AthenaDriver-method.html
@@ -86,7 +86,7 @@ NOTE: If you have set any environmental variables in .Renviron please restart yo
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbConvertTable.html
+++ b/docs/reference/dbConvertTable.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbDataType.html
+++ b/docs/reference/dbDataType.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbDisconnect.html
+++ b/docs/reference/dbDisconnect.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbExistsTable.html
+++ b/docs/reference/dbExistsTable.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbFetch.html
+++ b/docs/reference/dbFetch.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbGetInfo.html
+++ b/docs/reference/dbGetInfo.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbGetPartition.html
+++ b/docs/reference/dbGetPartition.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbGetQuery.html
+++ b/docs/reference/dbGetQuery.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbGetTables.html
+++ b/docs/reference/dbGetTables.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbHasCompleted.html
+++ b/docs/reference/dbHasCompleted.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbIsValid.html
+++ b/docs/reference/dbIsValid.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbListFields.html
+++ b/docs/reference/dbListFields.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbListTables.html
+++ b/docs/reference/dbListTables.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbQuote.html
+++ b/docs/reference/dbQuote.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbRemoveTable.html
+++ b/docs/reference/dbRemoveTable.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbShow.html
+++ b/docs/reference/dbShow.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/dbStatistics.html
+++ b/docs/reference/dbStatistics.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/db_compute.html
+++ b/docs/reference/db_compute.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/db_copy_to.html
+++ b/docs/reference/db_copy_to.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/db_desc.html
+++ b/docs/reference/db_desc.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/install_boto.html
+++ b/docs/reference/install_boto.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/session_token.html
+++ b/docs/reference/session_token.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/sqlCreateTable.html
+++ b/docs/reference/sqlCreateTable.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/sqlData.html
+++ b/docs/reference/sqlData.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/sql_translate_env.html
+++ b/docs/reference/sql_translate_env.html
@@ -74,7 +74,7 @@ DML Queries, Functions, and Operators" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 

--- a/docs/reference/work_group.html
+++ b/docs/reference/work_group.html
@@ -86,7 +86,7 @@ update_work_groupUpdates the workgroup with the specified name (link).
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">RAthena</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.10.1</span>
       </span>
     </div>
 


### PR DESCRIPTION
Update RAthena with noctua identified bug fixes: https://github.com/DyfanJones/noctua/pull/106#issue-493022689

> An issue connected to the Lake Formation service in AWS appeared:
>
>Lake Formation can be used to share content from one AWS account's glue catalog to another account.
>
>The problem arises, when:
>
>    A Lake formation share is created on account A
>    A resource link is created on account B
>    The share on acc A is removed leaving an 'oprhaned' resource link
>
>Now, when a user tries to establish a noctua/Athena connection, an error occurs, as the user on account B doesn't have >permission to get_tables on account B:s data catalog anymore.
>
>This pull request makes the get_tables error tolerant so that if access is denied, an empty list of tables is put forward.
>
>Probably the multiple tryCatche's are unnecessary now, but I hope this at least outlines the idea how one could address the issue.
>
>Br, Ossi