### PR TITLE
catch up RAthena to recent development in noctua

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Imports:
     methods,
     reticulate (>= 1.13),
     stats,
-    utils
+    utils,
+    uuid
 Suggests: 
     arrow,
     bit64,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 # RAthena 1.10.1.9000
 ## New Feature
 * Move `sql_escape_date` into `dplyr_integration.R` backend (#121). Thanks to @OssiLehtinen for developing Athena date translation.
+* Allow RAthena to append to a static AWS s3 location using uuid
+
+## Bug Fix
+* parquet file.types now use parameter `use_deprecated_int96_timestamps` set to `TRUE`. This puts POSIXct data type in to `java.sql.Timestamp` compatible format, such as `yyyy-MM-dd HH:mm:ss[.f...]`. Thanks to Christian N Wolz for highlight this issue.
+* `s3_upload_location` simplified how s3 location is built. Now s3.location parameter isn't affected and instead only additional components e.g. name, schema and partition.
 
 # RAthena 1.10.1
 ## Bug Fix

--- a/R/File_Parser.R
+++ b/R/File_Parser.R
@@ -68,82 +68,85 @@ athena_read_lines.athena_vroom <-
 
 # ==========================================================================
 # write method
-split_data <- function(method, x, ...){
-  UseMethod("split_data")
+write_batch <- function(value, split_vec, fun, max.batch, max_row, path, file.type, compress, ...){
+  
+  # create temp file
+  File <- paste(uuid::UUIDgenerate(), Compress(file.type, compress), sep = ".")
+  path <- file.path(path, File)
+  file_con <- if(file.type != "json") path else file(path)
+  
+  # split data.frame into chunks
+  chunk <- value[split_vec:min(max_row,(split_vec+max.batch-1)),]
+  
+  # write 
+  fun(chunk, file_con, ...)
+  
+  path
 }
 
-split_data.athena_data.table <- function(method, x, max.batch = Inf, path = tempdir(), 
-                                         sep = ",", compress = T, file.type = "csv"){
-  # Bypass splitter if not compressed
-  if(!compress){
-    file <- paste(paste(sample(letters, 10, replace = TRUE), collapse = ""), Compress(file.type, compress), sep = ".")
-    path <- file.path(path, file)
-    fwrite(x, path, sep = sep, quote = FALSE, showProgress = FALSE)
-    return(path)}
+dt_split <- function(value, max.batch, file.type, compress){
+  
+  if((file.type %in% c("parquet", "json") & is.infinite(max.batch)) || 
+     (file.type %in% c("csv", "tsv") & !compress & is.infinite(max.batch))) 
+    max.batch <- nrow(value)
   
   # set up split vec
-  max_row <- nrow(x)
-  split_10 <- .05 * max_row # default currently set to 20 split: https://github.com/DyfanJones/RAthena/issues/36
+  max_row <- nrow(value)
+  split_20 <- .05 * max_row # default currently set to 20 split: https://github.com/DyfanJones/RAthena/issues/36
   min.batch = 1000000 # min.batch sized at 1M
   
   # if batch is set to default
   if(is.infinite(max.batch)){
-    max.batch <- max(split_10, min.batch)
+    max.batch <- max(split_20, min.batch)
     split_vec <- seq(1, max_row, max.batch)
   }
   
   # if max.batch is set by user
   if(!is.infinite(max.batch)) split_vec <- seq(1, max_row, as.integer(max.batch))
-  
-  sapply(split_vec, write_batch_DT, dt = x, max.batch = max.batch,
-         max_row= max_row, path = path, sep = sep, file.type= file.type)
+  return(list(SplitVec = split_vec, MaxBatch = max.batch, MaxRow = max_row))
 }
 
-# write data.frame by batch data.table
-write_batch_DT <- function(split_vec, dt, max.batch, max_row, path, sep, file.type){
-  sample <- dt[split_vec:min(max_row,(split_vec+max.batch-1)),]
-  file <- paste(paste(sample(letters, 10, replace = TRUE), collapse = ""), Compress(file.type, TRUE), sep = ".")
-  path <- file.path(path, file)
-  fwrite(sample, path, sep = sep, quote = FALSE, showProgress = FALSE)
-  path
-}
-
-split_data.athena_vroom <- function(method, x, max.batch = Inf, path = tempdir(), 
-                                    sep = ",", compress = T, file.type = "csv"){
-  vroom_write <- pkg_method("vroom_write", "vroom")
-  # Bypass splitter if not compressed
-  if(!compress){
-    file <- paste(paste(sample(letters, 10, replace = TRUE), collapse = ""), Compress(file.type, compress), sep = ".")
-    path <- file.path(path, file)
-    vroom_write(x, path, delim = sep, quote = "none", progress = FALSE, escape = "none")
-    return(path)}
-  
-  # set up split vec
-  max_row <- nrow(x)
-  split_10 <- .05 * max_row # default currently set to 20 split: https://github.com/DyfanJones/RAthena/issues/36
-  min.batch = 1000000 # min.batch sized at 1M
-  
-  # if batch is set to default
-  if(is.infinite(max.batch)){
-    max.batch <- max(split_10, min.batch)
-    split_vec <- seq(1, max_row, max.batch)
+update_args <- function(file.type = "tsv", init_args = list(), compress = FALSE){
+  if(file.type ==  "parquet"){
+    write_parquet <- pkg_method("write_parquet", "arrow")
+    cp <- if(compress) "snappy" else NULL
+    init_args <- c(init_args,
+                   fun = write_parquet,
+                   use_deprecated_int96_timestamps = TRUE, # align POSIXct to athena timestamp: https://docs.aws.amazon.com/athena/latest/ug/data-types.html
+                   list(compression = cp))
+  } else if(file.type == "json") {
+    stream_out <- pkg_method("stream_out", "jsonlite")
+    init_args <- c(init_args,
+                   fun = stream_out,
+                   verbose = FALSE)
+  } else if(class(athena_option_env$file_parser) == "athena_data.table") {
+    init_args <- c(init_args,
+                   fun = data.table::fwrite,
+                   quote = FALSE,
+                   showProgress = FALSE)
+    if(file.type == "csv")
+      init_args <- c(init_args,
+                     sep = ",")
+    if(file.type == "tsv")
+      init_args <- c(init_args,
+                     sep = "\t")
+  } else if(class(athena_option_env$file_parser) == "athena_vroom"){
+    vroom_write <- pkg_method("vroom_write", "vroom")
+    init_args <- c(init_args,
+                   fun = vroom_write,
+                   quote = "none",
+                   progress = FALSE,
+                   escape = "none")
+    if(file.type == "csv")
+      init_args <- c(init_args,
+                     delim = ",")
+    if(file.type == "tsv")
+      init_args <- c(init_args,
+                     delim = "\t")
   }
-  
-  # if max.batch is set by user
-  if(!is.infinite(max.batch)) split_vec <- seq(1, max_row, as.integer(max.batch))
-  
-  sapply(split_vec, write_batch_vroom, dt = x, fun = vroom_write, max.batch = max.batch,
-         max_row= max_row, path = path, sep = sep, file.type= file.type)
-}
-
-# write data.frame by batch vroom
-write_batch_vroom <- function(split_vec, dt, fun, max.batch, max_row, path, sep, file.type){
-  sample <- dt[split_vec:min(max_row,(split_vec+max.batch-1)),]
-  file <- paste(paste(sample(letters, 10, replace = TRUE), collapse = ""), Compress(file.type, TRUE), sep = ".")
-  path <- file.path(path, file)
-  fun(sample,  path, delim = sep, quote = "none", progress = FALSE, escape = "none")
-  path
+  return(init_args)
 }
 
 # To enable vroom to compress files in parrallel then pigz is required: https://zlib.net/pigz/. 
 # pipe(sprintf("pigz > %s", path))
+

--- a/R/table.R
+++ b/R/table.R
@@ -534,6 +534,7 @@ s3_upload_location <- function(con, s3.location = NULL, name = NULL, partition =
   s3_info$key <- gsub("/$", "", s3_info$key)
   
   split_key <- unlist(strsplit(s3_info$key,"/"))
+  s3_info$key <- if(s3_info$key == "") NULL else s3_info$key
   
   # formatting partitions
   partition <- paste(names(partition), unname(partition), sep = "=", collapse = "/")

--- a/R/table.R
+++ b/R/table.R
@@ -105,9 +105,6 @@ Athena_write_table <-
     
     if(max.batch < 0) stop("`max.batch` has to be greater than 0", call. = F)
     
-    if(!is.infinite(max.batch) && file.type == "parquet") message("Info: parquet format is splittable and AWS Athena can read parquet format ",
-                                                                  "in parallel. `max.batch` is used for compressed `gzip` format which is not splittable.")
-    
     # use default s3_staging directory is s3.location isn't provided
     if (is.null(s3.location)) s3.location <- conn@info$s3_staging
     
@@ -120,8 +117,6 @@ Athena_write_table <-
     if(!grepl("\\.", name)) name <- paste(conn@info$dbms.name, name, sep = ".") 
 
     if (overwrite && append) stop("overwrite and append cannot both be TRUE", call. = FALSE)
-
-    if(append && is.null(partition)) stop("Athena requires the table to be partitioned to append", call. = FALSE)
     
     # Check if table already exists in the database
     found <- dbExistsTable(conn, name)
@@ -190,37 +185,31 @@ Athena_write_table <-
     if(is.null(field.types)) field.types <- dbDataType(conn, value)
     value <- sqlData(conn, value, row.names = row.names, file.type = file.type)
     
-    # check if arrow is installed before attempting to create parquet
-    if(file.type == "parquet"){
-      # compress file
-      t <- tempfile()
-      FileLocation <- paste(t, Compress(file.type, compress), sep =".")
-      
-      if(!requireNamespace("arrow", quietly=TRUE))
-        stop("The package arrow is required for R to utilise Apache Arrow to create parquet files.", call. = FALSE)
-      else {
-        cp <- if(compress) "snappy" else NULL
-        arrow::write_parquet(value, FileLocation, compression = cp)}
+    ############# write data frame to file type ####################
+    
+    # create temp location
+    temp_dir <- tempdir()
+    
+    # Split data into chunks
+    DtSplit <- dt_split(value, max.batch, file.type, compress)
+    
+    FileLocation <- character(length(DtSplit$SplitVec))
+    args <- list(value = value,
+                 max.batch = DtSplit$MaxBatch,
+                 max_row = DtSplit$MaxRow,
+                 path = temp_dir,
+                 file.type = file.type,
+                 compress = compress)
+    args <- update_args(file.type, args, compress)
+    
+    # write data.frame to backend in batch
+    for(i in seq_along(DtSplit$SplitVec)){
+      args$split_vec <- DtSplit$SplitVec[i]
+      FileLocation[[i]] <- do.call(write_batch, args)
     }
     
-    # check if jsonlite is installed before attempting to create json lines
-    if(file.type == "json"){
-      FileLocation <- tempfile()
-      stream_out <- pkg_method("stream_out", "jsonlite")
-      stream_out(value, con = file(FileLocation), verbose = FALSE)
-    }
+    ############# update data to aws s3 ###########################
     
-    # writes out csv/tsv, uses data.table for extra speed
-    if (file.type == "csv"){
-      FileLocation <- split_data(athena_option_env$file_parser,
-                                 value, max.batch = max.batch, compress = compress, file.type = file.type)
-    }
-    
-    if (file.type == "tsv"){
-      FileLocation <- split_data(athena_option_env$file_parser,
-                                 value, max.batch = max.batch, compress = compress, file.type = file.type, sep = "\t")
-    }
-
     # send data over to s3 bucket
     upload_data(conn, FileLocation, name, partition, s3.location, file.type, compress, append)
     
@@ -244,23 +233,25 @@ Athena_write_table <-
   }
 
 # send data to s3 is Athena registered location
-upload_data <- function(con, x, name, partition = NULL, s3.location= NULL,  file.type = NULL, compress = NULL, append = FALSE) {
-  
-  # Get schema and name
-  if (grepl("\\.", name)) {
-    schema <- gsub("\\..*", "" , name)
-    name <- gsub(".*\\.", "" , name)
-  } else {
-    schema <- con@info$dbms.name
-    name <- name}
+upload_data <- function(conn, x, name, partition = NULL, s3.location= NULL,  file.type = NULL, compress = NULL, append = FALSE) {
   
   # create s3 location components
-  s3_key <- s3_upload_location(x, schema, name, partition, s3.location, file.type, compress, append)
+  s3_location <- s3_upload_location(conn, s3.location, name, partition, append)
+  Bucket <- s3_location$Bucket
+  s3_location$Bucket <- NULL
+  s3_location <- Filter(Negate(is.null), s3_location)
+  s3_key <- paste(s3_location,collapse = "/")
   
-  tryCatch(s3 <- con@ptr$resource("s3"),
+  # Upload file with uuid to allow appending to same s3 location 
+  FileType <- if(compress) Compress(file.type, compress) else file.type
+  FileName <- paste(uuid::UUIDgenerate(n = length(x)),  FileType, sep = ".")
+  s3_key <- paste(s3_key, FileName, sep = "/")
+  
+  tryCatch(s3 <- conn@ptr$resource("s3"),
            error = function(e) py_error(e))
   for (i in 1:length(x)){
-    retry_api_call(s3$Bucket(s3_key[[1]])$upload_file(Filename = x[i], Key = s3_key[[2]][i]))}
+    retry_api_call(s3$Bucket(Bucket)$upload_file(Filename = x[i], Key = s3_key[i]))}
+  
   invisible(NULL)
 }
 
@@ -332,15 +323,20 @@ setMethod("sqlData", "AthenaConnection",
   field_names <- gsub("\\.", "_", make.names(names(Value), unique = TRUE))
   DIFF <- setdiff(field_names, names(Value))
   names(Value) <- field_names
-  if (length(DIFF) > 0) message("Info: data.frame colnames have been converted to align with Athena DDL naming convertions: \n",paste0(DIFF, collapse= ",\n"))
+  if (length(DIFF) > 0) 
+    message("Info: data.frame colnames have been converted to align with Athena DDL naming convertions: \n",
+            paste0(DIFF, collapse= ",\n"))
   
   # get R col types
   col_types <- sapply(Value, class)
   
-  # preprosing proxict format
-  posixct_cols <- names(Value)[sapply(col_types, function(x) "POSIXct" %in% x)]
-  # create timestamp in athena format: https://docs.aws.amazon.com/athena/latest/ug/data-types.html
-  for (col in posixct_cols) set(Value, j=col, value=strftime(Value[[col]], format="%Y-%m-%d %H:%M:%OS3"))
+  # leave POSIXct format for parquet file types
+  if(file.type != "parquet"){
+    # preprosing proxict format
+    posixct_cols <- names(Value)[sapply(col_types, function(x) "POSIXct" %in% x)]
+    # create timestamp in athena format: https://docs.aws.amazon.com/athena/latest/ug/data-types.html
+    for (col in posixct_cols) set(Value, j=col, value=strftime(Value[[col]], format="%Y-%m-%d %H:%M:%OS3"))
+  }
   
   # preprosing list format
   list_cols <- names(Value)[sapply(col_types, function(x) "list" %in% x)]
@@ -433,9 +429,13 @@ setMethod("sqlCreateTable", "AthenaConnection",
       schema <- con@info$dbms.name
       table1 <- table}
     
+    # create s3 location
+    s3_location <- s3_upload_location(con, s3.location, table, NULL, FALSE)
+    s3_location <- Filter(Negate(is.null), s3_location)
+    s3_location <- sprintf("'s3://%s/'", paste(s3_location,collapse = "/"))
+    
     table <- paste0(quote_identifier(con,  c(schema,table1)), collapse = ".")
     
-    s3.location <- gsub("/$", "", s3.location)
     if(grepl(table1, s3.location)){s3.location <- gsub(paste0("/", table1,"$"), "", s3.location)}
     s3.location <- paste0("'",s3.location,"/",schema,"/", table1,"/'")
     SQL(paste0(
@@ -443,7 +443,7 @@ setMethod("sqlCreateTable", "AthenaConnection",
       "  ", paste(field, collapse = ",\n  "), "\n)\n",
       partitioned(con, partition),
       FileType(file.type), "\n",
-      "LOCATION ",s3.location, "\n",
+      "LOCATION ",s3_location, "\n",
       header(file.type, compress)
     ))
   }
@@ -520,49 +520,43 @@ quote_identifier <- function(conn, x, ...) {
 }
 
 # moved s3 component builder to separate helper function to allow for unit tests
-s3_upload_location <- function(x, 
-                               schema, 
-                               name,
-                               partition = NULL,
-                               s3.location= NULL,
-                               file.type = NULL,
-                               compress = NULL,
-                               append = FALSE){
-  # formatting s3 partitions
-  partition <- unlist(partition)
-  partition <- paste(names(partition), unname(partition), sep = "=", collapse = "/")
-  
-  # s3_file name
-  FileType <- if(compress) Compress(file.type, compress) else file.type
-  FileName <- paste(if (length(x) > 1) paste0(name,"_", 1:length(x)) else name, FileType, sep = ".")
+s3_upload_location <- function(con, s3.location = NULL, name = NULL, partition = NULL, append = FALSE){
+  # Get schema and name
+  if (grepl("\\.", name)) {
+    schema <- gsub("\\..*", "" , name)
+    name <- gsub(".*\\.", "" , name)
+  } else {
+    schema <- con@info$dbms.name
+    name <- name}
   
   # s3 bucket and key split
   s3_info <- split_s3_uri(s3.location)
   s3_info$key <- gsub("/$", "", s3_info$key)
   
-  # Append data to existing s3 location
-  if(append) {return(list(s3_info$bucket,
-                          paste(s3_info$key, partition, FileName, sep = "/")))}
-  
-  if (partition != "") partition <- paste0(partition, "/")
   split_key <- unlist(strsplit(s3_info$key,"/"))
   
-  # remove name from s3 key
-  if(split_key[length(split_key)] == name || length(split_key) == 0)  split_key <- split_key[-length(split_key)]
+  # formatting partitions
+  partition <- paste(names(partition), unname(partition), sep = "=", collapse = "/")
+  partition <- if(partition == "") NULL else partition
   
-  # remove schema from s3 key
-  if(any(schema == split_key))  split_key <- split_key[-which(schema == split_key)]
+  # Leave s3 location if appending to table:
+  # Existing tables may not follow noctua s3 location schema
+  if (!append){
+    schema <- if(schema %in% tolower(split_key)) NULL else schema
+    name <- if(name %in% tolower(split_key)) NULL else name
+  } else {
+    schema <- NULL
+    name <- NULL
+  }
   
-  s3_info$key <- paste(split_key, collapse = "/")
-  if (s3_info$key != "") s3_info$key <- paste0(s3_info$key, "/")
-  
-  # s3 folder
-  schema <- paste0(schema, "/")
-  name <- paste0(name, "/")
-  
-  # S3 new syntax #73
-  list(s3_info$bucket,
-       sprintf("%s%s%s%s%s", s3_info$key, schema, name, partition, FileName))
+  return(
+    list(Bucket = s3_info$bucket,
+         Key = s3_info$key,
+         Schema = schema,
+         Name = name,
+         Partition = partition
+    )
+  )
 }
 
 # repair table using MSCK REPAIR TABLE for non partitioned and ALTER TABLE for partitioned tables
@@ -582,52 +576,29 @@ repair_table <- function(con, name, partition = NULL, s3.location = NULL, append
     res <- dbExecute(con, query)
     dbClearResult(res)
   } else {
-    # formatting s3 partitions
-    s3_partition <- unlist(partition)
-    s3_partition <- paste(names(s3_partition), unname(s3_partition), sep = "=", collapse = "/")
-    
-    # s3 bucket and key split
-    s3_info <- split_s3_uri(s3.location)
-    s3_info$key <- gsub("/$", "", s3_info$key)
-    
-    # Append data to existing s3 location
-    if(append) {s3.location <- sprintf("s3://%s/%s/%s/", s3_info$bucket, s3_info$key, s3_partition)
-    } else {
-      if (s3_partition != "") s3_partition <- paste0(s3_partition, "/")
-      split_key <- unlist(strsplit(s3_info$key,"/"))
-      
-      # remove name from s3 key
-      if(split_key[length(split_key)] == table1 || length(split_key) == 0)  split_key <- split_key[-length(split_key)]
-      
-      # remove schema from s3 key
-      if(any(schema == split_key))  split_key <- split_key[-which(schema == split_key)]
-      
-      s3_info$key <- paste(split_key, collapse = "/")
-      if (s3_info$key != "") s3_info$key <- paste0(s3_info$key, "/")
-      
-      # s3 folder
-      schema <- paste0(schema, "/")
-      table1 <- paste0(table1, "/")
-      
-      # S3 new syntax #73
-      s3.location <- sprintf("s3://%s/%s%s%s%s", s3_info$bucket, s3_info$key, schema, table1, s3_partition)
-    }
+    # create s3 location
+    s3_location <- s3_upload_location(con, s3.location, name, partition, append)
+    s3_location <- Filter(Negate(is.null), s3_location)
+    s3_location <- sprintf("s3://%s/", paste(s3_location,collapse = "/"))
     
     partition_names <- quote_identifier(con, names(partition))
     partition <- dbQuoteString(con, partition)
     partition <- paste0(partition_names, " = ", partition, collapse = ", ")
-    s3.location <- dbQuoteString(con, s3.location)
+    s3_location <- dbQuoteString(con, s3_location)
     
-    query <- SQL(paste0("ALTER TABLE ", table, " ADD IF NOT EXISTS\nPARTITION (", partition, ")\nLOCATION ", s3.location))
+    query <- SQL(paste0("ALTER TABLE ", table, " ADD IF NOT EXISTS\nPARTITION (", partition, ")\nLOCATION ", s3_location))
     res <- dbSendQuery(con, query)
     poll_result <- poll(res)
     dbClearResult(res)
     
     # If query failed, due to glue permissions default back to msck repair table
-    if(poll_result$QueryExecution$Status$State == "FAILED" && grepl(".*glue.*BatchCreatePartition.*AccessDeniedException", poll_result$QueryExecution$Status$StateChangeReason)) {
+    if(poll_result$QueryExecution$Status$State == "FAILED" && 
+       grepl(".*glue.*BatchCreatePartition.*AccessDeniedException", 
+             poll_result$QueryExecution$Status$StateChangeReason)) {
       query <- SQL(paste0("MSCK REPAIR TABLE ", table))
       res <- dbExecute(con, query)
       dbClearResult(res)
-    } else if (poll_result$QueryExecution$Status$State == "FAILED") stop(poll_result$QueryExecution$Status$StateChangeReason, call. = FALSE)
+    } else if (poll_result$QueryExecution$Status$State == "FAILED")
+        stop(poll_result$QueryExecution$Status$StateChangeReason, call. = FALSE)
   }
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -86,7 +86,7 @@ tbl8 =
 )
 PARTITIONED BY (`timestamp` STRING)
 ROW FORMAT  serde 'org.apache.hive.hcatalog.data.JsonSerDe'
-LOCATION '",Sys.getenv("rathena_s3_tbl"),"default/test_df/'\n")))
+LOCATION '",Sys.getenv("rathena_s3_tbl"),"test_df/default/'\n")))
 
 # static Athena Query Request Tests
 athena_test_req1 <-
@@ -113,4 +113,4 @@ athena_test_req4 <-
        ResultConfiguration = list(OutputLocation = Sys.getenv("rathena_s3_query")),
        WorkGroup = "primary")
 
-show_ddl <- SQL(paste0('CREATE EXTERNAL TABLE `default.test_df`(\n  `w` timestamp, \n  `x` int, \n  `y` string, \n  `z` boolean)\nPARTITIONED BY ( \n  `timestamp` string)\nROW FORMAT DELIMITED \n  FIELDS TERMINATED BY \'\\t\' \n  LINES TERMINATED BY \'\\n\' \nSTORED AS INPUTFORMAT \n  \'org.apache.hadoop.mapred.TextInputFormat\' \nOUTPUTFORMAT \n  \'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat\'\nLOCATION\n  \'' ,Sys.getenv("rathena_s3_tbl"), 'test_df/default\'\nTBLPROPERTIES (\n  \'skip.header.line.count\'=\'1\')'))
+show_ddl <- DBI::SQL(paste0('CREATE EXTERNAL TABLE `default.test_df`(\n  `w` timestamp, \n  `x` int, \n  `y` string, \n  `z` boolean)\nPARTITIONED BY ( \n  `timestamp` string)\nROW FORMAT DELIMITED \n  FIELDS TERMINATED BY \'\\t\' \n  LINES TERMINATED BY \'\\n\' \nSTORED AS INPUTFORMAT \n  \'org.apache.hadoop.mapred.TextInputFormat\' \nOUTPUTFORMAT \n  \'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat\'\nLOCATION\n  \'' ,Sys.getenv("rathena_s3_tbl"), 'test_df/default\'\nTBLPROPERTIES (\n  \'skip.header.line.count\'=\'1\')'))

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -22,7 +22,7 @@ DBI::SQL(paste0("CREATE EXTERNAL TABLE `default`.`test_df` (
 ROW FORMAT DELIMITED
 	FIELDS TERMINATED BY ','
 	LINES TERMINATED BY ", gsub("_","","'\\_n'"),
-"\nLOCATION '",Sys.getenv("rathena_s3_tbl"),"default/test_df/'
+"\nLOCATION '",Sys.getenv("rathena_s3_tbl"),"test_df/default/'
 TBLPROPERTIES (\"skip.header.line.count\"=\"1\");")),
 tbl2 = 
 DBI::SQL(paste0("CREATE EXTERNAL TABLE `default`.`test_df` (
@@ -32,7 +32,7 @@ DBI::SQL(paste0("CREATE EXTERNAL TABLE `default`.`test_df` (
 ROW FORMAT DELIMITED
 	FIELDS TERMINATED BY ','
 	LINES TERMINATED BY ", gsub("_","","'\\_n'"),
-           "\nLOCATION '",Sys.getenv("rathena_s3_tbl"),"default/test_df/'
+           "\nLOCATION '",Sys.getenv("rathena_s3_tbl"),"test_df/default/'
 TBLPROPERTIES (\"skip.header.line.count\"=\"1\",
 \t\t'compressionType'='gzip');")),
 tbl3 = 
@@ -43,7 +43,7 @@ DBI::SQL(paste0("CREATE EXTERNAL TABLE `default`.`test_df` (
 ROW FORMAT DELIMITED
 \tFIELDS TERMINATED BY '	'
 \tLINES TERMINATED BY ", gsub("_","","'\\_n'"),"
-LOCATION '",Sys.getenv("rathena_s3_tbl"),"default/test_df/'
+LOCATION '",Sys.getenv("rathena_s3_tbl"),"test_df/default/'
 TBLPROPERTIES (\"skip.header.line.count\"=\"1\");")),
 tbl4 = 
 DBI::SQL(paste0("CREATE EXTERNAL TABLE `default`.`test_df` (
@@ -53,7 +53,7 @@ DBI::SQL(paste0("CREATE EXTERNAL TABLE `default`.`test_df` (
 ROW FORMAT DELIMITED
 \tFIELDS TERMINATED BY '	'
 \tLINES TERMINATED BY ", gsub("_","","'\\_n'"),"
-LOCATION '",Sys.getenv("rathena_s3_tbl"),"default/test_df/'
+LOCATION '",Sys.getenv("rathena_s3_tbl"),"test_df/default/'
 TBLPROPERTIES (\"skip.header.line.count\"=\"1\",
 \t\t'compressionType'='gzip');")), 
 tbl5 = 
@@ -62,7 +62,7 @@ DBI::SQL(paste0("CREATE EXTERNAL TABLE `default`.`test_df` (
   `y` STRING
 )
 STORED AS PARQUET
-LOCATION '",Sys.getenv("rathena_s3_tbl"),"default/test_df/'\n;")),
+LOCATION '",Sys.getenv("rathena_s3_tbl"),"test_df/default/'\n;")),
 tbl6 = 
 DBI::SQL(paste0("CREATE EXTERNAL TABLE `default`.`test_df` (
   `x` INT,
@@ -70,7 +70,7 @@ DBI::SQL(paste0("CREATE EXTERNAL TABLE `default`.`test_df` (
 )
 PARTITIONED BY (`timestamp` STRING)
 STORED AS PARQUET
-LOCATION '",Sys.getenv("rathena_s3_tbl"),"default/test_df/'
+LOCATION '",Sys.getenv("rathena_s3_tbl"),"test_df/default/'
 tblproperties (\"parquet.compress\"=\"SNAPPY\");")),
 tbl7 = 
 DBI::SQL(paste0("CREATE EXTERNAL TABLE `default`.`test_df` (
@@ -78,7 +78,7 @@ DBI::SQL(paste0("CREATE EXTERNAL TABLE `default`.`test_df` (
   `y` STRING
 )
 ROW FORMAT  serde 'org.apache.hive.hcatalog.data.JsonSerDe'
-LOCATION '",Sys.getenv("rathena_s3_tbl"),"default/test_df/'\n")),
+LOCATION '",Sys.getenv("rathena_s3_tbl"),"test_df/default/'\n")),
 tbl8 = 
   DBI::SQL(paste0("CREATE EXTERNAL TABLE `default`.`test_df` (
   `x` INT,
@@ -113,14 +113,4 @@ athena_test_req4 <-
        ResultConfiguration = list(OutputLocation = Sys.getenv("rathena_s3_query")),
        WorkGroup = "primary")
 
-# static s3 path location
-s3_loc <- list(exp_s3_1 = "path/to/file/test/dummy_file/dummy_file.csv",
-               exp_s3_2 = "path/to/file/YEAR=2000/dummy_file.csv.gz",
-               exp_s3_3 = c("path/to/test/dummy_file/YEAR=2000/dummy_file_1.tsv", "path/to/test/dummy_file/YEAR=2000/dummy_file_2.tsv"),
-               exp_s3_4 = c("path/to/test/dummy_file/YEAR=2000/dummy_file_1.tsv.gz","path/to/test/dummy_file/YEAR=2000/dummy_file_2.tsv.gz"),
-               exp_s3_5 = "path/to/test/dummy_file/dummy_file.parquet",
-               exp_s3_6 = "path/to/dummy_file/YEAR=2000/dummy_file.snappy.parquet",
-               exp_s3_7 = "path/to/test/dummy_file/dummy_file.json",
-               exp_s3_8 = "path/to/dummy_file/YEAR=2000/dummy_file.json")
-
-show_ddl <- SQL('CREATE EXTERNAL TABLE `default.test_df`(\n  `w` timestamp, \n  `x` int, \n  `y` string, \n  `z` boolean)\nPARTITIONED BY ( \n  `timestamp` string)\nROW FORMAT DELIMITED \n  FIELDS TERMINATED BY \'\\t\' \n  LINES TERMINATED BY \'\\n\' \nSTORED AS INPUTFORMAT \n  \'org.apache.hadoop.mapred.TextInputFormat\' \nOUTPUTFORMAT \n  \'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat\'\nLOCATION\n  \'s3://test-rathena/default/test_df\'\nTBLPROPERTIES (\n  \'skip.header.line.count\'=\'1\')')
+show_ddl <- SQL(paste0('CREATE EXTERNAL TABLE `default.test_df`(\n  `w` timestamp, \n  `x` int, \n  `y` string, \n  `z` boolean)\nPARTITIONED BY ( \n  `timestamp` string)\nROW FORMAT DELIMITED \n  FIELDS TERMINATED BY \'\\t\' \n  LINES TERMINATED BY \'\\n\' \nSTORED AS INPUTFORMAT \n  \'org.apache.hadoop.mapred.TextInputFormat\' \nOUTPUTFORMAT \n  \'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat\'\nLOCATION\n  \'' ,Sys.getenv("rathena_s3_tbl"), 'test_df/default\'\nTBLPROPERTIES (\n  \'skip.header.line.count\'=\'1\')'))

--- a/tests/testthat/test-s3-upload-location.R
+++ b/tests/testthat/test-s3-upload-location.R
@@ -2,53 +2,54 @@ context("S3 upload location")
 
 test_that("Check if the S3 upload location is correctly built",{
   # Test connection is using AWS CLI to set profile_name 
-  
-  x <- c("dummy_file")
-  schema <- "test"
-  name <- "dummy_file"
-  s3.location <- "s3://bucket/path/to/file"
-  partition <- c("YEAR"= 2000)
+  conn <- dbConnect(RAthena::athena(),
+                    s3_staging_dir = Sys.getenv("rathena_s3_query"))
   
   # schema and name not s3 location 
-  s3_1 <- RAthena:::s3_upload_location(x, schema, name, file.type = "csv", compress = F, s3.location = s3.location, append = F)
-  s3_2 <- RAthena:::s3_upload_location(x, schema, name, file.type = "csv", compress = T, partition = partition, s3.location = s3.location, append = T)
-  
-  x <- c("dummy_file","dummy_file")
-  schema <- "test"
-  name <- "dummy_file"
-  s3.location <- "s3://bucket/path/to/test/dummy_file"
+  name <- "dummy_table"
+  s3.location <- "s3://bucket/path/to/file"
   partition <- c("YEAR"= 2000)
+  s3_1 <- RAthena:::s3_upload_location(conn, s3.location, name, partition)
+  s3_2 <- RAthena:::s3_upload_location(conn, s3.location, name, NULL)
   
-  # schema and name in s3 location 
-  s3_3 <- RAthena:::s3_upload_location(x, schema, name, file.type = "tsv", compress = F, partition = partition, s3.location = s3.location, append = F)
-  s3_4 <- RAthena:::s3_upload_location(x, schema, name, file.type = "tsv", compress = T, partition = partition, s3.location = s3.location, append = T)
+  # schema in s3 location 
+  s3.location <- "s3://bucket/path/to/file/schema"
+  name <- "schema.dummy_table"
+  s3_3 <- RAthena:::s3_upload_location(conn, s3.location, name, partition)
+  s3_4 <- RAthena:::s3_upload_location(conn, s3.location, name, NULL)
   
-  x <- c("dummy_file")
-  schema <- "test"
-  name <- "dummy_file"
-  s3.location <- "s3://bucket/path/to/dummy_file/"
-  partition <- c("YEAR"= 2000)
+  # name in s3 location 
+  s3.location <- "s3://bucket/path/to/file/dummy_table"
+  name <- "schema.dummy_table"
+  s3_3 <- RAthena:::s3_upload_location(conn, s3.location, name, partition)
+  s3_4 <- RAthena:::s3_upload_location(conn, s3.location, name, NULL)
   
-  # / at end of s3 location
-  s3_5 <- RAthena:::s3_upload_location(x, schema, name, file.type = "parquet", compress = F, s3.location = s3.location, append = F)
-  s3_6 <- RAthena:::s3_upload_location(x, schema, name, file.type = "parquet", compress = T, partition = partition, s3.location = s3.location, append = T)
+  # schema different s3 location
+  s3.location <- "s3://bucket/path/schema/to/file"
+  name <- "schema.dummy_table"
+  s3_5 <- RAthena:::s3_upload_location(conn, s3.location, name, partition)
+  s3_6 <- RAthena:::s3_upload_location(conn, s3.location, name, NULL)
   
-  x <- c("dummy_file")
-  schema <- "test"
-  name <- "dummy_file"
-  s3.location <- "s3://bucket/path/to/dummy_file/"
-  partition <- c("YEAR"= 2000)
+  # schema and table in s3 location
+  s3.location <- "s3://bucket/path/to/file/schema/dummy_table"
+  name <- "schema.dummy_table"
+  s3_7 <- RAthena:::s3_upload_location(conn, s3.location, name, partition)
+  s3_8 <- RAthena:::s3_upload_location(conn, s3.location, name, NULL)
   
-  # / at end of s3 location
-  s3_7 <- RAthena:::s3_upload_location(x, schema, name, file.type = "json", compress = F, s3.location = s3.location, append = F)
-  s3_8 <- RAthena:::s3_upload_location(x, schema, name, file.type = "json", compress = T, partition = partition, s3.location = s3.location, append = T)
+  # s3 location for existing table (should ignore schema/name/ partition)
+  s3.location <- "s3://bucket/path/to/file/dummy_table"
+  name <- "schema.dummy_table"
+  s3_9 <- RAthena:::s3_upload_location(conn, s3.location, name, partition, TRUE)
+  s3_10 <- RAthena:::s3_upload_location(conn, s3.location, name, NULL, TRUE)
   
-  expect_equal(s3_1[[2]], s3_loc$exp_s3_1)
-  expect_equal(s3_2[[2]], s3_loc$exp_s3_2)
-  expect_equal(s3_3[[2]], s3_loc$exp_s3_3)
-  expect_equal(s3_4[[2]], s3_loc$exp_s3_4)
-  expect_equal(s3_5[[2]], s3_loc$exp_s3_5)
-  expect_equal(s3_6[[2]], s3_loc$exp_s3_6)
-  expect_equal(s3_7[[2]], s3_loc$exp_s3_7)
-  expect_equal(s3_8[[2]], s3_loc$exp_s3_8)
+  expect_equal(s3_1, list(Bucket = "bucket", Key = "path/to/file", Schema = "default", Name = "dummy_table", Partition = "YEAR=2000"))
+  expect_equal(s3_2, list(Bucket = "bucket", Key = "path/to/file", Schema = "default", Name = "dummy_table", Partition = NULL))
+  expect_equal(s3_3, list(Bucket = "bucket", Key = "path/to/file/dummy_table", Schema = "schema", Name = NULL, Partition = "YEAR=2000"))
+  expect_equal(s3_4, list(Bucket = "bucket", Key = "path/to/file/dummy_table", Schema = "schema", Name = NULL, Partition = NULL))
+  expect_equal(s3_5, list(Bucket = "bucket", Key = "path/schema/to/file", Schema = NULL, Name = "dummy_table", Partition = "YEAR=2000"))
+  expect_equal(s3_6, list(Bucket = "bucket", Key = "path/schema/to/file", Schema = NULL, Name = "dummy_table", Partition = NULL))
+  expect_equal(s3_7, list(Bucket = "bucket", Key = "path/to/file/schema/dummy_table", Schema = NULL, Name = NULL, Partition = "YEAR=2000"))
+  expect_equal(s3_8, list(Bucket = "bucket", Key = "path/to/file/schema/dummy_table", Schema = NULL, Name = NULL, Partition = NULL))
+  expect_equal(s3_9, list(Bucket = "bucket", Key = "path/to/file/dummy_table", Schema = NULL, Name = NULL, Partition = "YEAR=2000"))
+  expect_equal(s3_10, list(Bucket = "bucket", Key = "path/to/file/dummy_table", Schema = NULL, Name = NULL, Partition = NULL))
 })

--- a/tests/testthat/test-upload-file-parameter.R
+++ b/tests/testthat/test-upload-file-parameter.R
@@ -1,0 +1,65 @@
+context("upload file setup")
+
+library(data.table)
+
+test_that("test file parser parameter setup",{
+  init_args = list()
+  
+  arg_1 <- RAthena:::update_args(file.type = "parquet", init_args)
+  arg_2 <- RAthena:::update_args(file.type = "parquet", init_args, compress = T)
+  arg_3 <- RAthena:::update_args(file.type = "json", init_args)
+  
+  # data.table parser
+  RAthena_options()
+  arg_4 <- RAthena:::update_args(file.type = "csv", init_args)
+  arg_5 <- RAthena:::update_args(file.type = "tsv", init_args)
+  
+  # vroom parser
+  RAthena_options(file_parser = "vroom")
+  arg_6 <- RAthena:::update_args(file.type = "csv", init_args)
+  arg_7 <- RAthena:::update_args(file.type = "tsv", init_args)
+  
+  expect_equal(arg_1, list(fun = arrow::write_parquet, use_deprecated_int96_timestamps = TRUE, compression = NULL))
+  expect_equal(arg_2, list(fun = arrow::write_parquet, use_deprecated_int96_timestamps = TRUE, compression = "snappy"))
+  expect_equal(arg_3, list(fun = jsonlite::stream_out, verbose = FALSE))
+  expect_equal(arg_4, list(fun = data.table::fwrite, quote= FALSE, showProgress = FALSE, sep = ","))
+  expect_equal(arg_5, list(fun = data.table::fwrite, quote= FALSE, showProgress = FALSE, sep = "\t"))
+  expect_equal(arg_6, list(fun = vroom::vroom_write, quote= "none", progress = FALSE, escape = "none", delim = ","))
+  expect_equal(arg_7, list(fun = vroom::vroom_write, quote= "none", progress = FALSE, escape = "none", delim = "\t"))
+})
+
+default_split <- c(1, 1000001)
+custom_split <- seq(1, 2e6, 100000)
+custom_chunk <- 100000
+
+test_that("test data frame is split correctly",{
+  # Test connection is using AWS CLI to set profile_name 
+  value = data.table(x = 1:2e6)
+  max_row = nrow(value)
+  
+  vec_1 <- RAthena:::dt_split(value, Inf, "csv", T)
+  vec_2 <- RAthena:::dt_split(value, Inf, "tsv", F)
+  vec_3 <- RAthena:::dt_split(value, custom_chunk, "tsv", T)
+  vec_4 <- RAthena:::dt_split(value, custom_chunk, "csv", F)
+  vec_5 <- RAthena:::dt_split(value, Inf, "parquet", T)
+  vec_6 <- RAthena:::dt_split(value, Inf, "parquet", F)
+  vec_7 <- RAthena:::dt_split(value, custom_chunk, "parquet", T)
+  vec_8 <- RAthena:::dt_split(value, custom_chunk, "parquet", F)
+  vec_9 <- RAthena:::dt_split(value, Inf, "json", T)
+  vec_10 <- RAthena:::dt_split(value, Inf, "json", F)
+  vec_11 <- RAthena:::dt_split(value, custom_chunk, "json", T)
+  vec_12 <- RAthena:::dt_split(value, custom_chunk, "json", F)
+  
+  expect_equal(vec_1, list(SplitVec = default_split, MaxBatch = 1e+06, MaxRow = max_row))
+  expect_equal(vec_2, list(SplitVec = 1, MaxBatch = max_row, MaxRow = max_row))
+  expect_equal(vec_3, list(SplitVec = custom_split, MaxBatch = custom_chunk, MaxRow = max_row))
+  expect_equal(vec_4, list(SplitVec = custom_split, MaxBatch = custom_chunk, MaxRow = max_row))
+  expect_equal(vec_5, list(SplitVec = 1, MaxBatch = max_row, MaxRow = max_row))
+  expect_equal(vec_6, list(SplitVec = 1, MaxBatch = max_row, MaxRow = max_row))
+  expect_equal(vec_7, list(SplitVec = custom_split, MaxBatch = custom_chunk, MaxRow = max_row))
+  expect_equal(vec_8, list(SplitVec = custom_split, MaxBatch = custom_chunk, MaxRow = max_row))
+  expect_equal(vec_9, list(SplitVec = 1, MaxBatch = max_row, MaxRow = max_row))
+  expect_equal(vec_10, list(SplitVec = 1, MaxBatch = max_row, MaxRow = max_row))
+  expect_equal(vec_11, list(SplitVec = custom_split, MaxBatch = custom_chunk, MaxRow = max_row))
+  expect_equal(vec_12, list(SplitVec = custom_split, MaxBatch = custom_chunk, MaxRow = max_row))
+})


### PR DESCRIPTION
## New Features
* Allow RAthena to append to a static AWS s3 location using uuid

## Bug Fix
* parquet file.types now use parameter `use_deprecated_int96_timestamps` set to `TRUE`. This puts POSIXct data type in to `java.sql.Timestamp` compatible format, such as `yyyy-MM-dd HH:mm:ss[.f...]`. Thanks to Christian N Wolz for highlight this issue.
* `s3_upload_location` simplified how s3 location is built. Now s3.location parameter isn't affected and instead only additional components e.g. name, schema and partition.