### PR TITLE
feature: pass extra boto3 parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RAthena
 Type: Package
 Title: Connect to 'AWS Athena' using 'Boto3' ('DBI' Interface)
-Version: 2.5.1
+Version: 2.5.1.9000
 Authors@R: person("Dyfan", "Jones", email="dyfan.r.jones@gmail.com", 
                   role= c("aut", "cre"))
 Description: Designed to be compatible with the R package 'DBI' (Database Interface)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# RAthena 2.5.1.9000
+## Feature:
+* Support extra boto3 parameters for `boto3.session.Session` class and `client` method (#169)
+* Support `endpoint_override` parameter allow default endpoints for each service to be overridden accordingly (#169)
+
 # RAthena 2.5.1
 ## Bug Fix:
 * Fixed unit test helper function `test_data` to use `size` parameter explicitly.

--- a/R/Connection.R
+++ b/R/Connection.R
@@ -41,18 +41,18 @@ AthenaConnection <- function(aws_access_key_id = NULL,
     profile_name = profile_name,
     .boto_param(kwargs, .SESSION_PASSING_ARGS)
   )
-  
   tryCatch(
     boto3 <- do.call(boto$Session, sess_kwargs),
     error = function(e) py_error(e)
   )
-  
   # stop connection if region_name is not set in backend or hardcoded
   if(is.null(boto3$region_name))
-    stop("AWS `region_name` is required to be set. Please set `region` in .config file, ",
-         "`AWS_REGION` in environment variables or `region_name` hard coded in `dbConnect()`.",
-         call. = FALSE)
-  
+    stop(
+      "AWS `region_name` is required to be set. Please set `region` in .config file, ",
+      "`AWS_REGION` in environment variables or `region_name` hard coded in `dbConnect()`.",
+      call. = FALSE
+    )
+  # set up any endpoint url for each aws service: athena, s3, glue
   endpoints = set_endpoints(endpoint_override)
   
   ptr_ll <- list(
@@ -72,23 +72,24 @@ AthenaConnection <- function(aws_access_key_id = NULL,
       }, error = function(e) py_error(e)
     )
   }
-    
   s3_staging_dir <- s3_staging_dir %||% get_aws_env("AWS_ATHENA_S3_STAGING_DIR")
   
   if(is.null(s3_staging_dir)) {
-    stop("Please set `s3_staging_dir` either in parameter `s3_staging_dir`, environmental varaible `AWS_ATHENA_S3_STAGING_DIR`",
-         "or when work_group is defined in `create_work_group()`", call. = F)
+    stop(
+      "Please set `s3_staging_dir` either in parameter `s3_staging_dir`, environmental varaible `AWS_ATHENA_S3_STAGING_DIR`",
+      "or when work_group is defined in `create_work_group()`", call. = F
+    )
   }
-  
-  info <- list(profile_name = profile_name, s3_staging = s3_staging_dir,
-               dbms.name = schema_name, work_group = work_group %||% "primary",
-               poll_interval = poll_interval, encryption_option = encryption_option,
-               kms_key = kms_key, expiration = aws_expiration,
-               timezone = character(),
-               keyboard_interrupt = keyboard_interrupt,
-               region_name = boto3$region_name,
-               endpoint_override = endpoints)
-  
+  info <- list(
+    profile_name = profile_name, s3_staging = s3_staging_dir,
+    dbms.name = schema_name, work_group = work_group %||% "primary",
+    poll_interval = poll_interval, encryption_option = encryption_option,
+    kms_key = kms_key, expiration = aws_expiration,
+    timezone = character(),
+    keyboard_interrupt = keyboard_interrupt,
+    region_name = boto3$region_name,
+    endpoint_override = endpoints
+  )
   res <- new(
     "AthenaConnection",
     ptr = list2env(ptr_ll, parent = emptyenv()),

--- a/R/Driver.R
+++ b/R/Driver.R
@@ -109,7 +109,47 @@ setMethod(
 #' @param keyboard_interrupt Stops AWS Athena process when R gets a keyboard interrupt, currently defaults to \code{TRUE}
 #' @param rstudio_conn_tab Optional to get AWS Athena Schema and display it in RStudio's Connections Tab.
 #'   Default set to \code{TRUE}.
-#' @param ... Any other parameter for Boto3 session: \href{https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html}{Boto3 session documentation}
+#' @param ... Passes parameters to \code{boto3.session.Session} and \code{client}.
+#' \itemize{
+#'     \item{\strong{boto3.session.Session}}
+#'     \itemize{
+#'         \item{\strong{botocore_session}} {(botocore.session.Session): Use this Botocore session instead
+#'             of creating a new default one.
+#'         }
+#'     }
+#'     \item{\strong{client}}
+#'     \itemize{
+#'         \item{\strong{config}} {(botocore.client.Config) -- Advanced client configuration options. If region_name
+#'             is specified in the client config, its value will take precedence over environment variables
+#'             and configuration values, but not over a region_name value passed explicitly to the method.
+#'             See \href{https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html}{botocore config documentation}
+#'             for more details.
+#'         }
+#'         \item{\strong{api_version}} {(string) -- The API version to use. By default, botocore will use the latest
+#'             API version when creating a client. You only need to specify this parameter if you want to
+#'             use a previous API version of the client.
+#'         }
+#'         \item{\strong{use_ssl}} {(boolean) -- Whether or not to use SSL. By default, SSL is used. Note that
+#'             not all services support non-ssl connections.
+#'         }
+#'         \item{\strong{verify}} {(boolean/string) -- Whether or not to verify SSL certificates. By default
+#'             SSL certificates are verified. You can provide the following values:
+#'             \itemize{
+#'                 \item{False - do not validate SSL certificates. SSL will still be used (unless use_ssl is False),
+#'                     but SSL certificates will not be verified.
+#'                 }
+#'                 \item{path/to/cert/bundle.pem - A filename of the CA cert bundle to uses. You can specify this
+#'                     argument if you want to use a different CA cert bundle than the one used by botocore.
+#'                }
+#'             }
+#'          }
+#'          \item{\strong{endpoint_url}} {(string) -- The complete URL to use for the constructed client. Normally,
+#'              botocore will automatically construct the appropriate URL to use when communicating with a
+#'              service. You can specify a complete URL (including the "http/https" scheme) to override this
+#'              behaviour. If this value is provided, then `use_ssl` is ignored.
+#'          }
+#'     }
+#'  }
 #' @aliases dbConnect
 #' @return \code{dbConnect()} returns a s4 class. This object is used to communicate with AWS Athena.
 #' @examples

--- a/R/Driver.R
+++ b/R/Driver.R
@@ -109,6 +109,12 @@ setMethod(
 #' @param keyboard_interrupt Stops AWS Athena process when R gets a keyboard interrupt, currently defaults to \code{TRUE}
 #' @param rstudio_conn_tab Optional to get AWS Athena Schema and display it in RStudio's Connections Tab.
 #'   Default set to \code{TRUE}.
+#' @param endpoint_override (character/list) The complete URL to use for the constructed client. Normally,
+#'    \code{botocore} will automatically construct the appropriate URL to use when communicating with a
+#'    service. You can specify a complete URL (including the "http/https" scheme) to override this
+#'    behaviour. If \code{endpoint_override} is a character then AWS Athena endpoint is overridden. To override
+#'    AWS S3 or AWS Glue endpoints a named list needs to be provided. The list can only have the following names ['athena', 's3', glue']
+#'    for example \code{list(glue = "https://glue.eu-west-1.amazonaws.com")}
 #' @param ... Passes parameters to \code{boto3.session.Session} and \code{client}.
 #' \itemize{
 #'     \item{\strong{boto3.session.Session}}
@@ -142,11 +148,6 @@ setMethod(
 #'                     argument if you want to use a different CA cert bundle than the one used by botocore.
 #'                }
 #'             }
-#'          }
-#'          \item{\strong{endpoint_url}} {(string) -- The complete URL to use for the constructed client. Normally,
-#'              botocore will automatically construct the appropriate URL to use when communicating with a
-#'              service. You can specify a complete URL (including the "http/https" scheme) to override this
-#'              behaviour. If this value is provided, then `use_ssl` is ignored.
 #'          }
 #'     }
 #'  }
@@ -204,6 +205,7 @@ setMethod(
            timezone = "UTC",
            keyboard_interrupt = TRUE,
            rstudio_conn_tab = TRUE,
+           endpoint_override = NULL,
            ...) {
     if(!py_module_available("boto3")){
       stop("Boto3 is not detected please install boto3 using either: `pip install boto3 numpy` in terminal or `install_boto()`.",
@@ -276,6 +278,7 @@ setMethod(
                             profile_name = profile_name, 
                             aws_expiration = aws_expiration,
                             keyboard_interrupt = keyboard_interrupt,
+                            endpoint_override = endpoint_override,
                             ...)
     if (is.null(timezone)) {
       # set empty timezone initially

--- a/R/utils.R
+++ b/R/utils.R
@@ -409,7 +409,7 @@ set_endpoints = function(endpoint_override){
   }
   if (is.list(endpoint_override)){
     if(length(names(endpoint_override)) == 0){
-      stop("The list needed to be a named list", call.=F)
+      stop("endpoint_override needed to be a named list", call.=F)
     }
     if(any(!(tolower(names(endpoint_override)) %in% c("athena", "s3", "glue")))){
       stop(

--- a/R/utils.R
+++ b/R/utils.R
@@ -397,3 +397,18 @@ info_msg = function(...){
   if (athena_option_env$verbose)
     message("INFO: ", ...)
 }
+
+.boto_param = function(param, default_param){
+  return(param[tolower(names(param)) %in% default_param])
+}
+.SESSION_PASSING_ARGS = c(
+  "botocore_session"
+)
+
+.CLIENT_PASSING_ARGS = c(
+  "config",
+  "api_version",
+  "use_ssl",
+  "verify",
+  "endpoint_url"
+)

--- a/R/utils.R
+++ b/R/utils.R
@@ -409,7 +409,7 @@ set_endpoints = function(endpoint_override){
   }
   if (is.list(endpoint_override)){
     if(length(names(endpoint_override)) == 0){
-      stop("endpoint_override needed to be a named list", call.=F)
+      stop("endpoint_override needed to be a named list or character", call.=F)
     }
     if(any(!(tolower(names(endpoint_override)) %in% c("athena", "s3", "glue")))){
       stop(

--- a/R/utils.R
+++ b/R/utils.R
@@ -398,6 +398,34 @@ info_msg = function(...){
     message("INFO: ", ...)
 }
 
+set_endpoints = function(endpoint_override){
+  if (is.null(endpoint_override)){
+    return(list())
+  }
+  if (is.character(endpoint_override)){
+    return(list(
+      athena = endpoint_override
+    ))
+  }
+  if (is.list(endpoint_override)){
+    if(length(names(endpoint_override)) == 0){
+      stop("The list needed to be a named list", call.=F)
+    }
+    if(any(!(tolower(names(endpoint_override)) %in% c("athena", "s3", "glue")))){
+      stop(
+        "The named list can only have the following names ['athena', 's3', glue']",
+        call.=F
+      )
+    }
+    names(endpoint_override) = tolower(names(endpoint_override))
+    endpoint_list = list()
+    endpoint_list$athena = endpoint_override$athena
+    endpoint_list$s3 = endpoint_override$s3
+    endpoint_list$glue = endpoint_override$glue
+    return(endpoint_list)
+  }
+}
+
 .boto_param = function(param, default_param){
   return(param[tolower(names(param)) %in% default_param])
 }
@@ -409,6 +437,5 @@ info_msg = function(...){
   "config",
   "api_version",
   "use_ssl",
-  "verify",
-  "endpoint_url"
+  "verify"
 )

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.re
 ![downloads](https://cranlogs.r-pkg.org/badges/RAthena)
 [![Codecov test coverage](https://codecov.io/gh/DyfanJones/rathena/branch/master/graph/badge.svg)](https://app.codecov.io/gh/DyfanJones/rathena?branch=master)
 [![R-CMD-check](https://github.com/DyfanJones/RAthena/workflows/R-CMD-check/badge.svg)](https://github.com/DyfanJones/RAthena/actions)
+[![RAthena status badge](https://dyfanjones.r-universe.dev/badges/RAthena)](https://dyfanjones.r-universe.dev)
 
 The goal of the `RAthena` package is to provide a DBI-compliant interface
 to Amazon’s Athena (<https://aws.amazon.com/athena/>) using `Boto3` SDK.

--- a/man/dbConnect-AthenaDriver-method.Rd
+++ b/man/dbConnect-AthenaDriver-method.Rd
@@ -94,7 +94,47 @@ If `NULL` then no timezone is set, which defaults to the server's time zone.
 \item{rstudio_conn_tab}{Optional to get AWS Athena Schema and display it in RStudio's Connections Tab.
 Default set to \code{TRUE}.}
 
-\item{...}{Any other parameter for Boto3 session: \href{https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html}{Boto3 session documentation}}
+\item{...}{Passes parameters to Boto3 Session and Client.
+\itemize{
+    \item{\strong{boto3.session.Session}}
+    \itemize{
+        \item{\strong{botocore_session}}{(botocore.session.Session): Use this Botocore session instead
+            of creating a new default one.
+        }
+    }
+    \item{\strong{client}}
+    \itemize{
+        \item{\strong{config}} {(botocore.client.Config) -- Advanced client configuration options. If region_name
+            is specified in the client config, its value will take precedence over environment variables
+            and configuration values, but not over a region_name value passed explicitly to the method.
+            See \href{https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html}{botocore config documentation}
+            for more details.
+        }
+        \item{\strong{api_version}}{(string) -- The API version to use. By default, botocore will use the latest
+            API version when creating a client. You only need to specify this parameter if you want to
+            use a previous API version of the client.
+        }
+        \item{\strong{use_ssl}}{(boolean) -- Whether or not to use SSL. By default, SSL is used. Note that
+            not all services support non-ssl connections.
+        }
+        \item{\strong{verify}}{(boolean/string) -- Whether or not to verify SSL certificates. By default
+            SSL certificates are verified. You can provide the following values:
+            \itemize{
+                \item{False - do not validate SSL certificates. SSL will still be used (unless use_ssl is False),
+                    but SSL certificates will not be verified.
+                }
+                \item{path/to/cert/bundle.pem - A filename of the CA cert bundle to uses. You can specify this
+                    argument if you want to use a different CA cert bundle than the one used by botocore.
+               }
+            }
+         }
+         \item{\strong{endpoint_url}}{(string) -- The complete URL to use for the constructed client. Normally,
+             botocore will automatically construct the appropriate URL to use when communicating with a
+             service. You can specify a complete URL (including the "http/https" scheme) to override this
+             behaviour. If this value is provided, then `use_ssl` is ignored.
+         }
+    }
+ }}
 }
 \value{
 \code{dbConnect()} returns a s4 class. This object is used to communicate with AWS Athena.

--- a/man/dbConnect-AthenaDriver-method.Rd
+++ b/man/dbConnect-AthenaDriver-method.Rd
@@ -28,6 +28,7 @@
   timezone = "UTC",
   keyboard_interrupt = TRUE,
   rstudio_conn_tab = TRUE,
+  endpoint_override = NULL,
   ...
 )
 }
@@ -94,6 +95,13 @@ If `NULL` then no timezone is set, which defaults to the server's time zone.
 \item{rstudio_conn_tab}{Optional to get AWS Athena Schema and display it in RStudio's Connections Tab.
 Default set to \code{TRUE}.}
 
+\item{endpoint_override}{(character/list) The complete URL to use for the constructed client. Normally,
+\code{botocore} will automatically construct the appropriate URL to use when communicating with a
+service. You can specify a complete URL (including the "http/https" scheme) to override this
+behaviour. If \code{endpoint_override} is a character then AWS Athena endpoint is overridden. To override
+AWS S3 or AWS Glue endpoints a named list needs to be provided. The list can only have the following names ['athena', 's3', glue']
+for example \code{list(glue = "https://glue.eu-west-1.amazonaws.com")}}
+
 \item{...}{Passes parameters to \code{boto3.session.Session} and \code{client}.
 \itemize{
     \item{\strong{boto3.session.Session}}
@@ -127,11 +135,6 @@ Default set to \code{TRUE}.}
                     argument if you want to use a different CA cert bundle than the one used by botocore.
                }
             }
-         }
-         \item{\strong{endpoint_url}} {(string) -- The complete URL to use for the constructed client. Normally,
-             botocore will automatically construct the appropriate URL to use when communicating with a
-             service. You can specify a complete URL (including the "http/https" scheme) to override this
-             behaviour. If this value is provided, then `use_ssl` is ignored.
          }
     }
  }}

--- a/man/dbConnect-AthenaDriver-method.Rd
+++ b/man/dbConnect-AthenaDriver-method.Rd
@@ -94,11 +94,11 @@ If `NULL` then no timezone is set, which defaults to the server's time zone.
 \item{rstudio_conn_tab}{Optional to get AWS Athena Schema and display it in RStudio's Connections Tab.
 Default set to \code{TRUE}.}
 
-\item{...}{Passes parameters to Boto3 Session and Client.
+\item{...}{Passes parameters to \code{boto3.session.Session} and \code{client}.
 \itemize{
     \item{\strong{boto3.session.Session}}
     \itemize{
-        \item{\strong{botocore_session}}{(botocore.session.Session): Use this Botocore session instead
+        \item{\strong{botocore_session}} {(botocore.session.Session): Use this Botocore session instead
             of creating a new default one.
         }
     }
@@ -110,14 +110,14 @@ Default set to \code{TRUE}.}
             See \href{https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html}{botocore config documentation}
             for more details.
         }
-        \item{\strong{api_version}}{(string) -- The API version to use. By default, botocore will use the latest
+        \item{\strong{api_version}} {(string) -- The API version to use. By default, botocore will use the latest
             API version when creating a client. You only need to specify this parameter if you want to
             use a previous API version of the client.
         }
-        \item{\strong{use_ssl}}{(boolean) -- Whether or not to use SSL. By default, SSL is used. Note that
+        \item{\strong{use_ssl}} {(boolean) -- Whether or not to use SSL. By default, SSL is used. Note that
             not all services support non-ssl connections.
         }
-        \item{\strong{verify}}{(boolean/string) -- Whether or not to verify SSL certificates. By default
+        \item{\strong{verify}} {(boolean/string) -- Whether or not to verify SSL certificates. By default
             SSL certificates are verified. You can provide the following values:
             \itemize{
                 \item{False - do not validate SSL certificates. SSL will still be used (unless use_ssl is False),
@@ -128,7 +128,7 @@ Default set to \code{TRUE}.}
                }
             }
          }
-         \item{\strong{endpoint_url}}{(string) -- The complete URL to use for the constructed client. Normally,
+         \item{\strong{endpoint_url}} {(string) -- The complete URL to use for the constructed client. Normally,
              botocore will automatically construct the appropriate URL to use when communicating with a
              service. You can specify a complete URL (including the "http/https" scheme) to override this
              behaviour. If this value is provided, then `use_ssl` is ignored.

--- a/man/install_boto.Rd
+++ b/man/install_boto.Rd
@@ -20,8 +20,8 @@ available on Windows. Note also that since this command runs without privilege
 the "system" method is available only on Windows.}
 
 \item{conda}{The path to a \code{conda} executable. Use \code{"auto"} to allow
-\code{reticulate} to automatically find an appropriate \code{conda} binary. See
-\strong{Finding Conda} for more details.}
+\code{reticulate} to automatically find an appropriate \code{conda} binary.
+See \strong{Finding Conda} and \code{\link[reticulate:conda-tools]{conda_binary()}} for more details.}
 
 \item{envname}{Name of Python environment to install within, by default environment name RAthena.}
 

--- a/tests/testthat/test-endpoint-override.R
+++ b/tests/testthat/test-endpoint-override.R
@@ -20,6 +20,6 @@ test_that("Test unsupported aws services", {
   )
   expect_error(
     set_endpoints(list()), 
-    "endpoint_override needed to be a named list"
+    "endpoint_override needed to be a named list or character"
   )
 })

--- a/tests/testthat/test-endpoint-override.R
+++ b/tests/testthat/test-endpoint-override.R
@@ -20,6 +20,6 @@ test_that("Test unsupported aws services", {
   )
   expect_error(
     set_endpoints(list()), 
-    "The list needed to be a named list"
+    "endpoint_override needed to be a named list"
   )
 })

--- a/tests/testthat/test-endpoint-override.R
+++ b/tests/testthat/test-endpoint-override.R
@@ -1,0 +1,14 @@
+test_that("Test set aws service endpoints", {
+  
+  expect_equal(set_endpoints(NULL),list())
+  expect_equal(set_endpoints("dummy"),list(athena = "dummy"))
+  expect_equal(set_endpoints(list(Athena="dummy")),list(athena = "dummy"))
+  expect_equal(
+    set_endpoints(list(athena="dummy.athena", s3="dummy.s3")), 
+    list(athena="dummy.athena", s3="dummy.s3")
+  )
+  expect_equal(
+    set_endpoints(list(athena="dummy.athena", s3="dummy.s3", glue = "dummy.glue")), 
+    list(athena="dummy.athena", s3="dummy.s3", glue = "dummy.glue")
+  )
+})

--- a/tests/testthat/test-endpoint-override.R
+++ b/tests/testthat/test-endpoint-override.R
@@ -12,3 +12,14 @@ test_that("Test set aws service endpoints", {
     list(athena="dummy.athena", s3="dummy.s3", glue = "dummy.glue")
   )
 })
+
+test_that("Test unsupported aws services", {
+  expect_error(
+    set_endpoints(list(dummy="dummy")), 
+    "The named list"
+  )
+  expect_error(
+    set_endpoints(list()), 
+    "The list needed to be a named list"
+  )
+})

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -8,7 +8,22 @@ context("Athena Metadata")
 df_col_info <- data.frame(field_name = c("w","x","y", "z", "timestamp"),
                           type = c("timestamp", "integer", "varchar", "boolean", "varchar"), stringsAsFactors = F)
 
-con_info = c("profile_name", "s3_staging","dbms.name","work_group", "poll_interval","encryption_option","kms_key","expiration", "keyboard_interrupt","region_name", "boto3", "RAthena", "timezone")
+con_info = c(
+  "profile_name",
+  "s3_staging",
+  "dbms.name",
+  "work_group",
+  "poll_interval",
+  "encryption_option",
+  "kms_key",
+  "expiration",
+  "keyboard_interrupt",
+  "region_name",
+  "boto3",
+  "RAthena",
+  "timezone",
+  "endpoint_override"
+)
 col_info_exp = c("w","x","y", "z", "timestamp")
 
 test_that("Returning meta data",{


### PR DESCRIPTION
- Support extra boto3 parameters for `Session` class and `client` method
- Support `endpoint_override` parameter allow default endpoints for each service to be overridden accordingly

ticket: https://github.com/DyfanJones/RAthena/issues/169